### PR TITLE
ci: configure release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = false
+git_tag_name = "v{{version}}"


### PR DESCRIPTION
We are keeping the crate versions in sync so we only need one tag. We are just putting the changelog in the github releases.