### PR TITLE
contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# How To Contribute To Aranya
+
+Our `CONTRIBUTING.md` is located in the aranya-project organization's `.github` repo:
+[CONTRIBUTING.md](https://github.com/aranya-project/.github/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ More documentation on Aranya is provided here:
 - [Aranya Overview](https://aranya-project.github.io/aranya-docs/overview/)
 - [Getting Started With Aranya](https://aranya-project.github.io/aranya-docs/walkthrough/)
 
+## Contributing
+
+Our `CONTRIBUTING.md` is located in the aranya-project organization's `.github` repo:
+[CONTRIBUTING.md](https://github.com/aranya-project/.github/blob/main/CONTRIBUTING.md)
+
 ## Getting Started
 
 ### Dependencies


### PR DESCRIPTION
Even though we have a `CONTRIBUTING.md` in the `.github` repo, it's not easy to find.
GitHub only provides links when opening an issue or pull request as a small link at the bottom that's barely noticeable.
The document isn't available on the repo's main landing page along with the README and other docs and isn't easy to find after cloning the repo.
This will make it easier for users locate the correct document while saving us the work of maintaining duplicate copies for each repo.