### PR TITLE
gh-pages: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @djohnson-spideroak @elagergren-spideroak @gknopf-aranya @jdygert-spok


### PR DESCRIPTION
Add `CODEOWNERS` for `gh-pages` branch.