### PR TITLE
Revert "gh-pages: exclude capi jekyll"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-exclude: capi/


### PR DESCRIPTION
Started getting 404 errors after removing the `.nojekyll` files. Reverting that change.

Add the `.nojekyll` file to `capi/` instead of each release so it's easier to maintain.

Reverts aranya-project/aranya#61