### PR TITLE
ci: cargo release bugfix to pull tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: ./.github/actions/setup
 
@@ -50,9 +53,6 @@ jobs:
         if: success() && steps.tag.outcome == 'success'
         run: |
           cargo release push -v --execute --no-confirm
-        # Continue on error so we don't get a CI failure (red X) when no release is needed.
-        # Each following step must check `steps.push.outcome` (NOT `steps.push.conclusion`).
-        continue-on-error: true
 
       - name: Version
         if: success()


### PR DESCRIPTION
The `release.yml` workflow was not pulling tags before attempting to create new tags:
https://github.com/aranya-project/aranya/actions/runs/13775343398/job/38523245239

This change ensure that tags are pulled when checking out the repo.
This way, the `release.yml` workflow will know whether a tag exists in the GitHub repo before attempting to create a new tag.