### PR TITLE
chore: release 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aranya-afc-util",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-keygen"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-util"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aranya-fast-channels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["SpiderOak, Inc."]
 edition = "2021"
 license = "AGPL-3.0-only"
@@ -56,11 +56,11 @@ aranya-runtime = { version = "0.4.0", features = ["std", "libc"] }
 spideroak-base58 = { version = "0.1.0" }
 buggy = { version = "0.1.0" }
 
-aranya-client = { version = "0.5.0", path = "crates/aranya-client" }
-aranya-daemon = { version = "0.5.0", path = "crates/aranya-daemon" }
-aranya-daemon-api = { version = "0.5.0", path = "crates/aranya-daemon-api" }
-aranya-keygen = { version = "0.5.0", path = "crates/aranya-keygen" }
-aranya-util = { version = "0.5.0", path = "crates/aranya-util" }
+aranya-client = { version = "0.5.1", path = "crates/aranya-client" }
+aranya-daemon = { version = "0.5.1", path = "crates/aranya-daemon" }
+aranya-daemon-api = { version = "0.5.1", path = "crates/aranya-daemon-api" }
+aranya-keygen = { version = "0.5.1", path = "crates/aranya-keygen" }
+aranya-util = { version = "0.5.1", path = "crates/aranya-util" }
 
 anyhow = { version = "1.0.86" }
 backon = { version = "1.2.0" }

--- a/crates/aranya-client/Cargo.toml
+++ b/crates/aranya-client/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { workspace = true, features = ["io-util", "macros", "net", "sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-aranya-daemon = { workspace = true }
+aranya-daemon = { path = "../aranya-daemon" }
 
 backon = { workspace = true }
 serial_test = { workspace = true }

--- a/templates/aranya-example/Cargo.lock
+++ b/templates/aranya-example/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-client"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05433dafe99d3a0ca99cafe44f6deef432dcd639000dfbbcc12cd2b09d7927aa"
 dependencies = [
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b5a4ed7d2986d27e9885aa56035bea5f32d48349c5657c458775917d39f9c7"
 dependencies = [
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon-api"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7cb04b509606a75ecbb52c90cf0bd9994f7d56acc11d38caeb007d8a45d5d0"
 dependencies = [
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-keygen"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0618c7769bcb3772276200aa8cec2a8ea114abd625a5c2c320ec6b6b7246779"
 dependencies = [
@@ -535,7 +535,7 @@ checksum = "c292729db9cbe6ad3c699bae15416c2e0596a9815046b49e27ad5d30ad54732d"
 
 [[package]]
 name = "aranya-util"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df943f3e6a0f398f7fa7d9e024438d2baebd5b347c2fbe2b82f090d34c31977f"
 dependencies = [

--- a/templates/aranya-example/Cargo.toml
+++ b/templates/aranya-example/Cargo.toml
@@ -30,10 +30,10 @@ wildcard_imports = "warn"
 
 [dependencies]
 # To allow `cargo-generate` to work, explicitly define dependency versions rather than importing the repo's workspace `Cargo.toml`.
-aranya-client = { version = "0.5.0" }
-aranya-daemon = { version = "0.5.0" }
-aranya-daemon-api = { version = "0.5.0" }
-aranya-util = { version = "0.5.0" }
+aranya-client = { version = "0.5.1" }
+aranya-daemon = { version = "0.5.1" }
+aranya-daemon-api = { version = "0.5.1" }
+aranya-util = { version = "0.5.1" }
 
 anyhow = { version = "1.0.94" }
 backon = { version = "1.3.0" }


### PR DESCRIPTION
Fixes a publishing issue of `aranya-client@0.5.0` using `aranya-daemon@0.5.0` as a dev-dependency. You generally don't use both path and version for dev-dependencies. In this case it should technically be possible but we hit https://github.com/crate-ci/cargo-release/issues/829