### PR TITLE
policy: make labels strings, not integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "aranya-crypto",
  "aranya-fast-channels",
  "aranya-util",
+ "buggy",
  "postcard",
  "serde",
  "spideroak-base58",

--- a/crates/aranya-client/src/lib.rs
+++ b/crates/aranya-client/src/lib.rs
@@ -17,7 +17,7 @@ pub mod error;
 
 #[doc(inline)]
 pub use crate::{
-    afc::{AfcId, FastChannels, Label, Message, PollData},
+    afc::{AfcId, FastChannels, LabelId, Message, PollData},
     client::{Client, Team},
     error::{AfcError, Error, Result},
 };

--- a/crates/aranya-client/tests/tests.rs
+++ b/crates/aranya-client/tests/tests.rs
@@ -24,7 +24,7 @@ use aranya_daemon::{
     Daemon,
 };
 use aranya_daemon_api::{DeviceId, KeyBundle, NetIdentifier, Role};
-use aranya_fast_channels::{Label, Seq};
+use aranya_fast_channels::Seq;
 use aranya_util::addr::Addr;
 use backon::{ExponentialBuilder, Retryable};
 use buggy::BugExt;
@@ -558,13 +558,13 @@ async fn test_afc_one_way_two_chans() -> Result<()> {
     sleep(sleep_interval).await;
 
     // operator assigns labels for AFC channels.
-    let label1 = Label::new(1);
-    operator_team.create_label(label1).await?;
+    let label1 = "LABEL_2";
+    let label1_id = operator_team.create_label(label1).await?;
     operator_team.assign_label(team.membera.id, label1).await?;
     operator_team.assign_label(team.memberb.id, label1).await?;
 
-    let label2 = Label::new(2);
-    operator_team.create_label(label2).await?;
+    let label2 = "LABEL_2";
+    let label2_id = operator_team.create_label(label2).await?;
     operator_team.assign_label(team.membera.id, label2).await?;
     operator_team.assign_label(team.memberb.id, label2).await?;
 
@@ -631,7 +631,7 @@ async fn test_afc_one_way_two_chans() -> Result<()> {
         // assume `got.addr` is correct here.
         address: got.address,
         channel: afc_id1,
-        label: label1,
+        label: label1_id,
         seq: Seq::ZERO,
     };
     assert_eq!(got, want);
@@ -648,7 +648,7 @@ async fn test_afc_one_way_two_chans() -> Result<()> {
         // assume `got.addr` is correct here.
         address: got.address,
         channel: afc_id2,
-        label: label2,
+        label: label2_id,
         seq: Seq::ZERO,
     };
     assert_eq!(got, want);
@@ -792,8 +792,8 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
     // ==== BASIC SETUP DONE ====
 
     // operator assigns labels for AFC channels.
-    let label1 = Label::new(1);
-    operator_team.create_label(label1).await?;
+    let label1 = "LABEL_1";
+    let label1_id = operator_team.create_label(label1).await?;
     operator_team.assign_label(team.membera.id, label1).await?;
     operator_team.assign_label(team.memberb.id, label1).await?;
 
@@ -838,7 +838,7 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
         // assume `got.addr` is correct here.
         address: got.address,
         channel: afc_id1,
-        label: label1,
+        label: label1_id,
         seq: Seq::ZERO,
     };
     assert_eq!(got, want, "a->b");
@@ -858,7 +858,7 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
         data: msg.as_bytes().to_vec(),
         address: memberb_afc_addr,
         channel: afc_id1,
-        label: label1,
+        label: label1_id,
         seq: Seq::ZERO,
     };
     let got = team
@@ -1008,8 +1008,8 @@ async fn test_afc_monotonic_seq() -> Result<()> {
     // ==== BASIC SETUP DONE ====
 
     // operator assigns labels for AFC channels.
-    let label1 = Label::new(1);
-    operator_team.create_label(label1).await?;
+    let label1 = "LABEL_1";
+    let label1_id = operator_team.create_label(label1).await?;
     operator_team.assign_label(team.membera.id, label1).await?;
     operator_team.assign_label(team.memberb.id, label1).await?;
 
@@ -1059,7 +1059,7 @@ async fn test_afc_monotonic_seq() -> Result<()> {
             // so assume `got.addr` is correct here.
             address: got.address,
             channel: afc_id1,
-            label: label1,
+            label: label1_id,
             seq,
         };
         assert_eq!(got, want, "a->b");
@@ -1080,7 +1080,7 @@ async fn test_afc_monotonic_seq() -> Result<()> {
             data: msg.into(),
             address: memberb_afc_addr,
             channel: afc_id1,
-            label: label1,
+            label: label1_id,
             seq,
         };
         let got = team

--- a/crates/aranya-daemon-api/Cargo.toml
+++ b/crates/aranya-daemon-api/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 aranya-crypto = { workspace = true }
 aranya-fast-channels = { workspace = true }
 aranya-util = { workspace = true }
+buggy = { workspace = true, features = ["std"] }
 spideroak-base58 = { workspace = true, features = ["std"] }
 
 anyhow = { workspace = true }

--- a/crates/aranya-daemon-api/src/service.rs
+++ b/crates/aranya-daemon-api/src/service.rs
@@ -10,6 +10,7 @@ use aranya_crypto::{
 };
 use aranya_fast_channels::{Label, NodeId};
 use aranya_util::Addr;
+use buggy::Bug;
 use serde::{Deserialize, Serialize};
 use spideroak_base58::ToBase58;
 use tracing::error;
@@ -21,6 +22,13 @@ pub type CS = DefaultCipherSuite;
 // TODO: enum?
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Error(String);
+
+impl From<Bug> for Error {
+    fn from(err: Bug) -> Self {
+        error!(%err);
+        Self(err.to_string())
+    }
+}
 
 impl From<anyhow::Error> for Error {
     fn from(err: anyhow::Error) -> Self {
@@ -183,22 +191,22 @@ pub trait DaemonApi {
         name: NetIdentifier,
     ) -> Result<()>;
 
-    /// Create a fast channels label.
-    async fn create_label(team: TeamId, label: Label) -> Result<()>;
-    /// Delete a fast channels label.
-    async fn delete_label(team: TeamId, label: Label) -> Result<()>;
+    /// Create an AFC/AQC label.
+    async fn create_label(team: TeamId, label: String) -> Result<Label>;
+    /// Delete an AFC/AQC label.
+    async fn delete_label(team: TeamId, label: String) -> Result<Label>;
 
-    /// Assign a fast channels label to a device.
-    async fn assign_label(team: TeamId, device: DeviceId, label: Label) -> Result<()>;
-    /// Revoke a fast channels label from a device.
-    async fn revoke_label(team: TeamId, device: DeviceId, label: Label) -> Result<()>;
+    /// Assign an AFC/AQC label.
+    async fn assign_label(team: TeamId, device: DeviceId, label: String) -> Result<()>;
+    /// Revoke an AFC/AQC label.
+    async fn revoke_label(team: TeamId, device: DeviceId, label: String) -> Result<()>;
     /// Create a fast channel.
     async fn create_afc_bidi_channel(
         team: TeamId,
         peer: NetIdentifier,
         node_id: NodeId,
-        label: Label,
-    ) -> Result<(AfcId, AfcCtrl)>;
+        label: String,
+    ) -> Result<(AfcId, AfcCtrl, Label)>;
     /// Delete a fast channel.
     async fn delete_afc_channel(chan: AfcId) -> Result<AfcCtrl>;
     /// Receive a fast channel ctrl message.

--- a/crates/aranya-daemon/src/policy.md
+++ b/crates/aranya-daemon/src/policy.md
@@ -271,6 +271,12 @@ function next_label_id() int {
     return label_id
 }
 
+/// Shorthand for retrieving the `Label` fact.
+function get_label_id(label string) int {
+    let v = check_unwrap query Label[label: label]
+    return v.label_id
+}
+
 // Returns the channel operation for a particular label.
 function get_allowed_op(device_id id, label_id int) enum ChanOp {
     let assigned_label = check_unwrap query AssignedLabel[label_id: label_id, device_id: device_id]
@@ -1323,6 +1329,7 @@ action create_afc_bidi_channel(peer_id id, label string) {
     let author_id = device::current_device_id()
     let author = get_valid_device(author_id)
     let peer_enc_pk = get_enc_pk(peer_id)
+    let label_id = get_label_id(label)
 
     let channel = afc::create_bidi_channel(
         parent_cmd_id,
@@ -1330,7 +1337,7 @@ action create_afc_bidi_channel(peer_id id, label string) {
         author_id,
         peer_enc_pk,
         peer_id,
-        label,
+        label_id,
     )
 
     publish AfcCreateBidiChannel {
@@ -1452,6 +1459,7 @@ action create_afc_uni_channel(writer_id id, reader_id id, label string) {
     let author = get_valid_device(device::current_device_id())
     let peer_id = select_peer_id(author.device_id, writer_id, reader_id)
     let peer_enc_pk = get_enc_pk(peer_id)
+    let label_id = get_label_id(label)
 
     let channel = afc::create_uni_channel(
         parent_cmd_id,
@@ -1459,7 +1467,7 @@ action create_afc_uni_channel(writer_id id, reader_id id, label string) {
         peer_enc_pk,
         writer_id,
         reader_id,
-        label,
+        label_id,
     )
 
     publish AfcCreateUniChannel {

--- a/crates/aranya-daemon/src/policy.rs
+++ b/crates/aranya-daemon/src/policy.rs
@@ -110,25 +110,29 @@ pub struct OperatorRevoked {
 /// LabelDefined policy effect.
 #[effect]
 pub struct LabelDefined {
-    pub label: i64,
+    pub author_id: Id,
+    pub label: String,
+    pub label_id: i64,
 }
 /// LabelUndefined policy effect.
 #[effect]
 pub struct LabelUndefined {
-    pub label: i64,
+    pub author_id: Id,
+    pub label: String,
+    pub label_id: i64,
 }
 /// LabelAssigned policy effect.
 #[effect]
 pub struct LabelAssigned {
     pub device_id: Id,
-    pub label: i64,
+    pub label: String,
     pub op: ChanOp,
 }
 /// LabelRevoked policy effect.
 #[effect]
 pub struct LabelRevoked {
     pub device_id: Id,
-    pub label: i64,
+    pub label: String,
 }
 /// NetworkNameSet policy effect.
 #[effect]
@@ -149,7 +153,8 @@ pub struct AfcBidiChannelCreated {
     pub author_enc_key_id: Id,
     pub peer_id: Id,
     pub peer_enc_pk: Vec<u8>,
-    pub label: i64,
+    pub label: String,
+    pub label_id: i64,
     pub channel_key_id: Id,
 }
 /// AfcBidiChannelReceived policy effect.
@@ -160,7 +165,8 @@ pub struct AfcBidiChannelReceived {
     pub author_enc_pk: Vec<u8>,
     pub peer_id: Id,
     pub peer_enc_key_id: Id,
-    pub label: i64,
+    pub label: String,
+    pub label_id: i64,
     pub encap: Vec<u8>,
 }
 /// AfcUniChannelCreated policy effect.
@@ -172,7 +178,8 @@ pub struct AfcUniChannelCreated {
     pub reader_id: Id,
     pub author_enc_key_id: Id,
     pub peer_enc_pk: Vec<u8>,
-    pub label: i64,
+    pub label: String,
+    pub label_id: i64,
     pub channel_key_id: Id,
 }
 /// AfcUniChannelReceived policy effect.
@@ -184,7 +191,8 @@ pub struct AfcUniChannelReceived {
     pub reader_id: Id,
     pub author_enc_pk: Vec<u8>,
     pub peer_enc_key_id: Id,
-    pub label: i64,
+    pub label: String,
+    pub label_id: i64,
     pub encap: Vec<u8>,
 }
 /// Implements all supported policy actions.
@@ -200,15 +208,15 @@ pub trait ActorExt {
     fn remove_member(&mut self, device_id: Id) -> Result<(), ClientError>;
     fn assign_role(&mut self, device_id: Id, role: Role) -> Result<(), ClientError>;
     fn revoke_role(&mut self, device_id: Id, role: Role) -> Result<(), ClientError>;
-    fn define_label(&mut self, label: i64) -> Result<(), ClientError>;
-    fn undefine_label(&mut self, label: i64) -> Result<(), ClientError>;
+    fn define_label(&mut self, label: String) -> Result<(), ClientError>;
+    fn undefine_label(&mut self, label: String) -> Result<(), ClientError>;
     fn assign_label(
         &mut self,
         device_id: Id,
-        label: i64,
+        label: String,
         op: ChanOp,
     ) -> Result<(), ClientError>;
-    fn revoke_label(&mut self, device_id: Id, label: i64) -> Result<(), ClientError>;
+    fn revoke_label(&mut self, device_id: Id, label: String) -> Result<(), ClientError>;
     fn set_network_name(
         &mut self,
         device_id: Id,
@@ -218,12 +226,12 @@ pub trait ActorExt {
     fn create_afc_bidi_channel(
         &mut self,
         peer_id: Id,
-        label: i64,
+        label: String,
     ) -> Result<(), ClientError>;
     fn create_afc_uni_channel(
         &mut self,
         writer_id: Id,
         reader_id: Id,
-        label: i64,
+        label: String,
     ) -> Result<(), ClientError>;
 }


### PR DESCRIPTION
To keep compatibility with AFC, map labels to 32-bit integers.

Fixes #152