### PR TITLE
capi: device role query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-codegen"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7282a2ca427234133077457b1c043624a4df5e21c87e17b898818e6e621b2f24"
+checksum = "7482a25508d9c6315a97acd08f62528552deb011835311e53651e525ae967cb7"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08945571ec11b531506e95da567512181520ab00b450e6eef947a97567ad148b"
+checksum = "85b5302d59a1f172a8bc5ff6b8463bc16bfb58f8c853addc204c3e4380cd0647"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4522117cae376f1f428a77ff85f603521394964a6f679a8225a7b3ff6b30e9c"
+checksum = "1c97a7ee1b24b93873230d68acaa4410574a53b009f93bb1776b3d62c73d960f"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ wildcard_imports = "warn"
 
 [workspace.dependencies]
 aranya-afc-util = { version = "0.5.0", features = ["alloc"] }
-aranya-capi-core = { version = "0.2.1" }
-aranya-capi-codegen = { version = "0.2.2" }
+aranya-capi-core = { version = "0.2.2" }
+aranya-capi-codegen = { version = "0.2.3" }
 aranya-crypto = { version = "0.4.0", features = ["alloc", "fs-keystore", "clone-aead", "std"] }
 aranya-crypto-ffi = { version = "0.5.0" }
 aranya-device-ffi = { version = "0.5.0" }

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -91,7 +91,7 @@
 #define ARANYA_DEVICE_ID_STR_LEN (((64 * 1375) / 1000) + 1)
 
 /**
- * The size in bytes of a [`Role`] converted to a human-readable string.
+ * The size in bytes of a `Role` converted to a human-readable string.
  */
 #define ARANYA_ROLE_STR_LEN 256
 

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -91,6 +91,11 @@
 #define ARANYA_DEVICE_ID_STR_LEN (((64 * 1375) / 1000) + 1)
 
 /**
+ * The size in bytes of a `DeviceId` converted to a human-readable base64 string.
+ */
+#define ARANYA_ROLE_STR_LEN 256
+
+/**
  * An error code.
  *
  * For extended error information, see [`AranyaExtError`](@ref AranyaExtError).
@@ -1764,6 +1769,49 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
 AranyaError aranya_device_id_to_str(struct AranyaDeviceId device,
                                     char *str,
                                     size_t *str_len);
+
+/**
+ * Query device role on team.
+ *
+ * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
+ * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
+ * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
+ * @param __output the device's role [`AranyaRole`](@ref AranyaRole).
+ *
+ * @relates AranyaClient.
+ */
+AranyaError aranya_query_device_role(struct AranyaClient *client,
+                                     const struct AranyaTeamId *team,
+                                     const struct AranyaDeviceId *device,
+                                     AranyaRole *__output);
+
+/**
+ * Query device role on team.
+ *
+ * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
+ * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
+ * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
+ * @param __output the device's role [`AranyaRole`](@ref AranyaRole).
+ *
+ * @relates AranyaClient.
+ */
+AranyaError aranya_query_device_role_ext(struct AranyaClient *client,
+                                         const struct AranyaTeamId *team,
+                                         const struct AranyaDeviceId *device,
+                                         AranyaRole *__output,
+                                         struct AranyaExtError *__ext_err);
+
+/**
+ * Writes the human-readable encoding of `role` to `str`.
+ *
+ * To always succeed, `str` must be at least `ARANYA_ROLE_STR_LEN` bytes long.
+ *
+ * @param role [`AranyaRole`](@ref AranyaRole).
+ * @param role string [`AranyaRole`](@ref AranyaRole).
+ *
+ * @relates AranyaError.
+ */
+AranyaError aranya_role_to_str(AranyaRole role, char *str, size_t *str_len);
 
 /**
  * Query device's keybundle.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -91,7 +91,7 @@
 #define ARANYA_DEVICE_ID_STR_LEN (((64 * 1375) / 1000) + 1)
 
 /**
- * The size in bytes of a `DeviceId` converted to a human-readable base64 string.
+ * The size in bytes of a [`Role`] converted to a human-readable string.
  */
 #define ARANYA_ROLE_STR_LEN 256
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1271,7 +1271,7 @@ pub fn query_device_role(
     Ok(role.into())
 }
 
-/// The size in bytes of a [`Role`] converted to a human-readable string.
+/// The size in bytes of a `Role` converted to a human-readable string.
 pub const ARANYA_ROLE_STR_LEN: u64 = 256;
 
 /// Writes the human-readable encoding of `role` to `str`.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1271,7 +1271,7 @@ pub fn query_device_role(
     Ok(role.into())
 }
 
-/// The size in bytes of a `DeviceId` converted to a human-readable base64 string.
+/// The size in bytes of a [`Role`] converted to a human-readable string.
 pub const ARANYA_ROLE_STR_LEN: u64 = 256;
 
 /// Writes the human-readable encoding of `role` to `str`.

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -424,6 +424,19 @@ AranyaError run(Team *t) {
         printf("label: %u at index: %zu/%zu \r\n", label_result, i, labels_len);
     }
 
+    AranyaRole memberb_role;
+    err = aranya_query_device_role(&t->clients.operator.client, &t->id,
+                                   &t->clients.memberb.id, &memberb_role);
+    EXPECT("error querying memberb role", err);
+    size_t role_str_len = ARANYA_ROLE_STR_LEN;
+    char *role_str      = malloc(ARANYA_ROLE_STR_LEN);
+    aranya_role_to_str(memberb_role, role_str, &role_str_len);
+    printf(
+        "%s role: %s"
+        "\r\n",
+        t->clients_arr[MEMBERB].name, role_str);
+    free(role_str);
+
     AranyaKeyBundle memberb_keybundle;
     err = aranya_query_device_keybundle(&t->clients.operator.client, &t->id,
                                         &t->clients.memberb.id,


### PR DESCRIPTION
Add API for querying device role.
Include method for converting the device role to a C string for display.

Blocked by ID-based roles:
https://github.com/aranya-project/aranya-docs/issues/91
https://github.com/aranya-project/aranya/issues/181