### PR TITLE
aranya-client-capi: access to bytes in ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-codegen"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7282a2ca427234133077457b1c043624a4df5e21c87e17b898818e6e621b2f24"
+checksum = "7482a25508d9c6315a97acd08f62528552deb011835311e53651e525ae967cb7"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08945571ec11b531506e95da567512181520ab00b450e6eef947a97567ad148b"
+checksum = "d2d2b6c96c6654a3847da44ce1d8389ec5a4cefe76af2da72ad533c7a3ff1370"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4522117cae376f1f428a77ff85f603521394964a6f679a8225a7b3ff6b30e9c"
+checksum = "1c97a7ee1b24b93873230d68acaa4410574a53b009f93bb1776b3d62c73d960f"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "aranya-capi-codegen",
  "aranya-capi-core",
  "aranya-client",
+ "aranya-crypto",
  "aranya-daemon-api",
  "aranya-fast-channels",
  "aranya-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ wildcard_imports = "warn"
 
 [workspace.dependencies]
 aranya-afc-util = { version = "0.5.0", features = ["alloc"] }
-aranya-capi-core = { version = "0.2.1" }
+aranya-capi-core = { version = "0.2.3" }
 aranya-capi-codegen = { version = "0.2.2" }
 aranya-crypto = { version = "0.4.0", features = ["alloc", "fs-keystore", "clone-aead", "std"] }
 aranya-crypto-ffi = { version = "0.5.0" }

--- a/crates/aranya-client-capi/Cargo.toml
+++ b/crates/aranya-client-capi/Cargo.toml
@@ -29,6 +29,7 @@ aranya-daemon-api = { workspace = true }
 aranya-util = { workspace = true }
 
 aranya-capi-core = { workspace = true }
+aranya-crypto = { workspace = true }
 aranya-fast-channels = { workspace = true }
 buggy = { workspace = true }
 

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -86,9 +86,14 @@
 #define ARANYA_DURATION_NANOSECONDS 1
 
 /**
- * The size in bytes of a `DeviceId` converted to a human-readable base64 string.
+ * The size in bytes of an ID converted to a human-readable base58 string.
  */
-#define ARANYA_DEVICE_ID_STR_LEN (((64 * 1375) / 1000) + 1)
+#define ARANYA_ID_STR_LEN (((64 * 1375) / 1000) + 1)
+
+/**
+ * The size in bytes of an ID
+ */
+#define ARANYA_ID_LEN 64
 
 /**
  * An error code.
@@ -1156,16 +1161,81 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
 /**
  * Writes the human-readable encoding of `device` to `str`.
  *
- * To always succeed, `str` must be at least `ARANYA_DEVICE_ID_STR_LEN` bytes long.
+ * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
  *
  * @param device ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param device ID string [`AranyaDeviceId`](@ref AranyaDeviceId).
+ * @param str ID string [`AranyaDeviceId`](@ref AranyaDeviceId).
+ * @param str_len returns the length of `str`
  *
  * @relates AranyaError.
  */
 AranyaError aranya_device_id_to_str(struct AranyaDeviceId device,
                                     char *str,
                                     size_t *str_len);
+
+/**
+ * Returns the bytes of `device_id` as an array.
+ *
+ * @param device ID [`AranyaDeviceId`](@ref AranyaDeviceId).
+ *
+ */
+AranyaError aranya_device_id_to_bytes(const struct AranyaDeviceId *device_id,
+                                      uint8_t *bytes,
+                                      size_t bytes_len);
+
+/**
+ * Writes the human-readable encoding of `team` to `str`.
+ *
+ * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
+ *
+ * @param team ID [`AranyaTeamId`](@ref AranyaTeamId).
+ * @param str ID string [`AranyaTeamId`](@ref AranyaTeamId).
+ * @param str_len returns the length of `str`
+ *
+ * @relates AranyaError.
+ */
+AranyaError aranya_team_id_to_str(struct AranyaTeamId team,
+                                  char *str,
+                                  size_t *str_len);
+
+/**
+ * Returns the bytes of `team_id` as an array.
+ *
+ * @param device ID [`AranyaTeamId`](@ref AranyaTeamId).
+ *
+ */
+AranyaError aranya_team_id_to_bytes(const struct AranyaTeamId *team_id,
+                                    uint8_t *bytes,
+                                    size_t bytes_len);
+
+#if defined(ENABLE_AFC)
+/**
+ * Writes the human-readable encoding of `channel` to `str`.
+ *
+ * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
+ *
+ * @param channel ID [`AranyaChannelId`](@ref AranyaChannelId).
+ * @param str ID string [`AranyaChannelId`](@ref AranyaChannelId).
+ * @param str_len returns the length of `str`
+ *
+ * @relates AranyaError.
+ */
+AranyaError aranya_channel_id_to_str(struct AranyaChannelId channel,
+                                     char *str,
+                                     size_t *str_len);
+#endif
+
+#if defined(ENABLE_AFC)
+/**
+ * Returns the bytes of `channel_id` as an array.
+ *
+ * @param device ID [`AranyaChannelId`](@ref AranyaChannelId).
+ *
+ */
+AranyaError aranya_channel_id_to_bytes(const struct AranyaChannelId *channel_id,
+                                       uint8_t *bytes,
+                                       size_t bytes_len);
+#endif
 
 /**
  * Query device's keybundle.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -1208,35 +1208,6 @@ AranyaError aranya_team_id_to_bytes(const struct AranyaTeamId *team_id,
                                     uint8_t *bytes,
                                     size_t bytes_len);
 
-#if defined(ENABLE_AFC)
-/**
- * Writes the human-readable encoding of `channel` to `str`.
- *
- * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
- *
- * @param channel ID [`AranyaChannelId`](@ref AranyaChannelId).
- * @param str ID string [`AranyaChannelId`](@ref AranyaChannelId).
- * @param str_len returns the length of `str`
- *
- * @relates AranyaError.
- */
-AranyaError aranya_channel_id_to_str(struct AranyaChannelId channel,
-                                     char *str,
-                                     size_t *str_len);
-#endif
-
-#if defined(ENABLE_AFC)
-/**
- * Returns the bytes of `channel_id` as an array.
- *
- * @param device ID [`AranyaChannelId`](@ref AranyaChannelId).
- *
- */
-AranyaError aranya_channel_id_to_bytes(const struct AranyaChannelId *channel_id,
-                                       uint8_t *bytes,
-                                       size_t bytes_len);
-#endif
-
 /**
  * Query device's keybundle.
  *

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -1153,34 +1153,19 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
                                              struct AranyaExtError *__ext_err);
 
 /**
- * Writes the human-readable encoding of `device` to `str`.
+ * Writes the human-readable encoding of `id` to `str`.
  *
  * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
  *
- * @param device ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param str ID string [`AranyaDeviceId`](@ref AranyaDeviceId).
+ * @param device ID [`AranyaId`](@ref AranyaId).
+ * @param str ID string [`AranyaId`](@ref AranyaId).
  * @param str_len returns the length of `str`
  *
  * @relates AranyaError.
  */
-AranyaError aranya_device_id_to_str(const struct AranyaDeviceId *device,
-                                    char *str,
-                                    size_t *str_len);
-
-/**
- * Writes the human-readable encoding of `team` to `str`.
- *
- * To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
- *
- * @param team ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param str ID string [`AranyaTeamId`](@ref AranyaTeamId).
- * @param str_len returns the length of `str`
- *
- * @relates AranyaError.
- */
-AranyaError aranya_team_id_to_str(const struct AranyaTeamId *team,
-                                  char *str,
-                                  size_t *str_len);
+AranyaError aranya_id_to_str(const struct AranyaId *id,
+                             char *str,
+                             size_t *str_len);
 
 /**
  * Query device's keybundle.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -77,6 +77,11 @@
 #endif /* ARANYA_PACKED */
 
 
+/**
+ * The size in bytes of an ID
+ */
+#define ARANYA_ID_LEN 64
+
 #define ARANYA_DURATION_SECONDS (1000 * ARANYA_DURATION_MILLISECONDS)
 
 #define ARANYA_DURATION_MILLISECONDS (1000 * ARANYA_DURATION_MICROSECONDS)
@@ -89,11 +94,6 @@
  * The size in bytes of an ID converted to a human-readable base58 string.
  */
 #define ARANYA_ID_STR_LEN (((64 * 1375) / 1000) + 1)
-
-/**
- * The size in bytes of an ID
- */
-#define ARANYA_ID_LEN 64
 
 /**
  * An error code.
@@ -279,28 +279,22 @@ typedef struct ARANYA_DESIGNATED_INIT AranyaKeyBundle {
     size_t enc_key_len;
 } AranyaKeyBundle;
 
+typedef struct AranyaId {
+    uint8_t bytes[ARANYA_ID_LEN];
+} AranyaId;
+
 /**
  * Device ID.
  */
-typedef struct ARANYA_ALIGNED(1) AranyaDeviceId {
-    /**
-     * This field only exists for size purposes. It is
-     * UNDEFINED BEHAVIOR to read from or write to it.
-     * @private
-     */
-    uint8_t __for_size_only[64];
+typedef struct AranyaDeviceId {
+    struct AranyaId id;
 } AranyaDeviceId;
 
 /**
  * Team ID.
  */
-typedef struct ARANYA_ALIGNED(1) AranyaTeamId {
-    /**
-     * This field only exists for size purposes. It is
-     * UNDEFINED BEHAVIOR to read from or write to it.
-     * @private
-     */
-    uint8_t __for_size_only[64];
+typedef struct AranyaTeamId {
+    struct AranyaId id;
 } AranyaTeamId;
 
 /**
@@ -1169,19 +1163,9 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
  *
  * @relates AranyaError.
  */
-AranyaError aranya_device_id_to_str(struct AranyaDeviceId device,
+AranyaError aranya_device_id_to_str(const struct AranyaDeviceId *device,
                                     char *str,
                                     size_t *str_len);
-
-/**
- * Returns the bytes of `device_id` as an array.
- *
- * @param device ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- *
- */
-AranyaError aranya_device_id_to_bytes(const struct AranyaDeviceId *device_id,
-                                      uint8_t *bytes,
-                                      size_t bytes_len);
 
 /**
  * Writes the human-readable encoding of `team` to `str`.
@@ -1194,19 +1178,9 @@ AranyaError aranya_device_id_to_bytes(const struct AranyaDeviceId *device_id,
  *
  * @relates AranyaError.
  */
-AranyaError aranya_team_id_to_str(struct AranyaTeamId team,
+AranyaError aranya_team_id_to_str(const struct AranyaTeamId *team,
                                   char *str,
                                   size_t *str_len);
-
-/**
- * Returns the bytes of `team_id` as an array.
- *
- * @param device ID [`AranyaTeamId`](@ref AranyaTeamId).
- *
- */
-AranyaError aranya_team_id_to_bytes(const struct AranyaTeamId *team_id,
-                                    uint8_t *bytes,
-                                    size_t bytes_len);
 
 /**
  * Query device's keybundle.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -93,7 +93,7 @@
 /**
  * The size in bytes of an ID converted to a human-readable base58 string.
  */
-#define ARANYA_ID_STR_LEN (((64 * 1375) / 1000) + 1)
+#define ARANYA_ID_STR_LEN (((ARANYA_ID_LEN * 1375) / 1000) + 1)
 
 /**
  * An error code.
@@ -1166,6 +1166,16 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
 AranyaError aranya_id_to_str(const struct AranyaId *id,
                              char *str,
                              size_t *str_len);
+
+/**
+ * Decodes `str` into an [`AranyaId`](@ref AranyaId).
+ *
+ *
+ * @param str pointer to a null-terminated string.
+ *
+ * @relates AranyaError.
+ */
+AranyaError aranya_id_from_str(const char *str, struct AranyaId *__output);
 
 /**
  * Query device's keybundle.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -1161,7 +1161,7 @@ AranyaError aranya_query_devices_on_team_ext(struct AranyaClient *client,
  * @param str ID string [`AranyaId`](@ref AranyaId).
  * @param str_len returns the length of `str`
  *
- * @relates AranyaError.
+ * @relates AranyaId.
  */
 AranyaError aranya_id_to_str(const struct AranyaId *id,
                              char *str,
@@ -1173,7 +1173,7 @@ AranyaError aranya_id_to_str(const struct AranyaId *id,
  *
  * @param str pointer to a null-terminated string.
  *
- * @relates AranyaError.
+ * @relates AranyaId.
  */
 AranyaError aranya_id_from_str(const char *str, struct AranyaId *__output);
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -186,6 +186,12 @@ pub struct Id {
     bytes: [u8; ARANYA_ID_LEN],
 }
 
+impl From<&Id> for aranya_crypto::Id {
+    fn from(value: &Id) -> Self {
+        Self::from(value.bytes)
+    }
+}
+
 /// Team ID.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -1294,43 +1300,23 @@ pub fn query_devices_on_team(
 /// The size in bytes of an ID converted to a human-readable base58 string.
 pub const ARANYA_ID_STR_LEN: u64 = (64 * 1375) / 1000 + 1;
 
-/// Writes the human-readable encoding of `device` to `str`.
+/// Writes the human-readable encoding of `id` to `str`.
 ///
 /// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
 ///
-/// @param device ID [`DeviceId`].
-/// @param str ID string [`DeviceId`].
+/// @param device ID [`Id`].
+/// @param str ID string [`Id`].
 /// @param str_len returns the length of `str`
 ///
 /// @relates AranyaError.
 #[aranya_capi_core::no_ext_error]
-pub fn device_id_to_str(
-    device: &DeviceId,
+pub fn id_to_str(
+    id: &Id,
     str: &mut MaybeUninit<c_char>,
     str_len: &mut usize,
 ) -> Result<(), imp::Error> {
     let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
-    aranya_capi_core::write_c_str(str, &aranya_daemon_api::DeviceId::from(device), str_len)?;
-    Ok(())
-}
-
-/// Writes the human-readable encoding of `team` to `str`.
-///
-/// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
-///
-/// @param team ID [`TeamId`].
-/// @param str ID string [`TeamId`].
-/// @param str_len returns the length of `str`
-///
-/// @relates AranyaError.
-#[aranya_capi_core::no_ext_error]
-pub fn team_id_to_str(
-    team: &TeamId,
-    str: &mut MaybeUninit<c_char>,
-    str_len: &mut usize,
-) -> Result<(), imp::Error> {
-    let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
-    aranya_capi_core::write_c_str(str, &aranya_daemon_api::TeamId::from(team), str_len)?;
+    aranya_capi_core::write_c_str(str, &aranya_crypto::Id::from(id), str_len)?;
     Ok(())
 }
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -176,7 +176,7 @@ pub type Client = Safe<imp::Client>;
 pub const ARANYA_ID_LEN: usize = 64;
 
 const _: () = {
-    assert!(ARANYA_ID_LEN == size_of::<aranya_fast_channels::crypto::aranya_crypto::Id>());
+    assert!(ARANYA_ID_LEN == size_of::<aranya_crypto::Id>());
 };
 
 // Aranya ID

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1,7 +1,5 @@
-#[cfg(feature = "afc")]
-use core::ptr;
-use core::{ffi::c_char, ops::DerefMut, slice};
-use std::{ffi::OsStr, mem, os::unix::ffi::OsStrExt};
+use core::{ffi::c_char, ops::DerefMut, ptr, slice};
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use aranya_capi_core::{prelude::*, ErrorCode, InvalidArg};
 use tracing::debug;
@@ -188,7 +186,8 @@ pub struct Id {
 
 impl AsRef<aranya_crypto::Id> for Id {
     fn as_ref(&self) -> &aranya_crypto::Id {
-        unsafe { mem::transmute(self) }
+        // SAFETY: Each type is a struct with a single field containing an array of 64 bytes
+        unsafe { &*ptr::from_ref::<[u8; ARANYA_ID_LEN]>(&self.bytes).cast::<aranya_crypto::Id>() }
     }
 }
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1315,7 +1315,7 @@ pub const ARANYA_ID_STR_LEN: usize = (ARANYA_ID_LEN * 1375) / 1000 + 1;
 /// @param str ID string [`Id`].
 /// @param str_len returns the length of `str`
 ///
-/// @relates AranyaError.
+/// @relates AranyaId.
 #[aranya_capi_core::no_ext_error]
 pub fn id_to_str(
     id: &Id,
@@ -1332,7 +1332,7 @@ pub fn id_to_str(
 ///
 /// @param str pointer to a null-terminated string.
 ///
-/// @relates AranyaError.
+/// @relates AranyaId.
 #[aranya_capi_core::no_ext_error]
 pub unsafe fn id_from_str(str: *const c_char) -> Result<Id, imp::Error> {
     // SAFETY: Caller must ensure the pointer is a valid C String.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "afc")]
 use core::ptr;
 use core::{ffi::c_char, ops::DerefMut, slice};
-use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+use std::{ffi::OsStr, mem, os::unix::ffi::OsStrExt};
 
 use aranya_capi_core::{prelude::*, ErrorCode, InvalidArg};
 use tracing::debug;
@@ -186,9 +186,9 @@ pub struct Id {
     bytes: [u8; ARANYA_ID_LEN],
 }
 
-impl From<&Id> for aranya_crypto::Id {
-    fn from(value: &Id) -> Self {
-        Self::from(value.bytes)
+impl AsRef<aranya_crypto::Id> for Id {
+    fn as_ref(&self) -> &aranya_crypto::Id {
+        unsafe { mem::transmute(self) }
     }
 }
 
@@ -1316,7 +1316,7 @@ pub fn id_to_str(
     str_len: &mut usize,
 ) -> Result<(), imp::Error> {
     let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
-    aranya_capi_core::write_c_str(str, &aranya_crypto::Id::from(id), str_len)?;
+    aranya_capi_core::write_c_str(str, id.as_ref(), str_len)?;
     Ok(())
 }
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1226,15 +1226,23 @@ pub fn query_devices_on_team(
     Ok(())
 }
 
-/// The size in bytes of a `DeviceId` converted to a human-readable base64 string.
-pub const ARANYA_DEVICE_ID_STR_LEN: u64 = (64 * 1375) / 1000 + 1;
+/// The size in bytes of an ID converted to a human-readable base58 string.
+pub const ARANYA_ID_STR_LEN: u64 = (64 * 1375) / 1000 + 1;
+
+/// The size in bytes of an ID
+pub const ARANYA_ID_LEN: u64 = 64; // size_of::<aranya_fast_channels::crypto::aranya_crypto::Id>() as u64;
+
+const _: () = {
+    assert!(ARANYA_ID_LEN == size_of::<aranya_fast_channels::crypto::aranya_crypto::Id>() as u64);
+};
 
 /// Writes the human-readable encoding of `device` to `str`.
 ///
-/// To always succeed, `str` must be at least `ARANYA_DEVICE_ID_STR_LEN` bytes long.
+/// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
 ///
 /// @param device ID [`DeviceId`].
-/// @param device ID string [`DeviceId`].
+/// @param str ID string [`DeviceId`].
+/// @param str_len returns the length of `str`
 ///
 /// @relates AranyaError.
 #[aranya_capi_core::no_ext_error]
@@ -1246,6 +1254,97 @@ pub fn device_id_to_str(
     let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
     aranya_capi_core::write_c_str(str, &device.0, str_len)?;
     Ok(())
+}
+
+/// Returns the bytes of `device_id` as an array.
+///
+/// @param device ID [`DeviceId`].
+///
+/// cbindgen:ptrs-as-arrays=[[bytes; 64]]
+// TODO: bytes param comment
+#[aranya_capi_core::no_ext_error]
+pub fn device_id_to_bytes(device_id: &DeviceId, bytes: &mut [u8]) -> Result<(), imp::Error> {
+    let src = device_id.0.as_array();
+    if bytes.len() >= src.len() {
+        bytes[0..src.len()].copy_from_slice(src);
+        Ok(())
+    } else {
+        Err(imp::Error::BufferTooSmall)
+    }
+}
+
+/// Writes the human-readable encoding of `team` to `str`.
+///
+/// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
+///
+/// @param team ID [`TeamId`].
+/// @param str ID string [`TeamId`].
+/// @param str_len returns the length of `str`
+///
+/// @relates AranyaError.
+#[aranya_capi_core::no_ext_error]
+pub fn team_id_to_str(
+    team: TeamId,
+    str: &mut MaybeUninit<c_char>,
+    str_len: &mut usize,
+) -> Result<(), imp::Error> {
+    let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
+    aranya_capi_core::write_c_str(str, &team.0, str_len)?;
+    Ok(())
+}
+
+/// Returns the bytes of `team_id` as an array.
+///
+/// @param device ID [`TeamId`].
+///
+// TODO: bytes param comment
+#[aranya_capi_core::no_ext_error]
+pub fn team_id_to_bytes(team_id: &TeamId, bytes: &mut [u8]) -> Result<(), imp::Error> {
+    let src = team_id.0.as_array();
+    if bytes.len() >= src.len() {
+        bytes[0..src.len()].copy_from_slice(src);
+        Ok(())
+    } else {
+        Err(imp::Error::BufferTooSmall)
+    }
+}
+
+/// Writes the human-readable encoding of `channel` to `str`.
+///
+/// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
+///
+/// @param channel ID [`ChannelId`].
+/// @param str ID string [`ChannelId`].
+/// @param str_len returns the length of `str`
+///
+/// @relates AranyaError.
+#[aranya_capi_core::no_ext_error]
+#[cfg(feature = "afc")]
+pub fn channel_id_to_str(
+    channel: ChannelId,
+    str: &mut MaybeUninit<c_char>,
+    str_len: &mut usize,
+) -> Result<(), imp::Error> {
+    let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
+    aranya_capi_core::write_c_str(str, &channel.0, str_len)?;
+    Ok(())
+}
+
+/// Returns the bytes of `channel_id` as an array.
+///
+/// @param device ID [`ChannelId`].
+///
+// TODO: bytes param comment
+#[aranya_capi_core::no_ext_error]
+#[cfg(feature = "afc")]
+pub fn channel_id_to_bytes(channel_id: &ChannelId, bytes: &mut [u8]) {
+    let src = channel_id.0.as_array();
+    if bytes.len() >= src.len() {
+        bytes[0..src.len()].copy_from_slice(src);
+        Ok(())
+    } else {
+        Err(imp::Error::BufferTooSmall)
+    }
 }
 
 // TODO: query_device_role

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1309,44 +1309,6 @@ pub fn team_id_to_bytes(team_id: &TeamId, bytes: &mut [u8]) -> Result<(), imp::E
     }
 }
 
-/// Writes the human-readable encoding of `channel` to `str`.
-///
-/// To always succeed, `str` must be at least `ARANYA_ID_STR_LEN` bytes long.
-///
-/// @param channel ID [`ChannelId`].
-/// @param str ID string [`ChannelId`].
-/// @param str_len returns the length of `str`
-///
-/// @relates AranyaError.
-#[aranya_capi_core::no_ext_error]
-#[cfg(feature = "afc")]
-pub fn channel_id_to_str(
-    channel: ChannelId,
-    str: &mut MaybeUninit<c_char>,
-    str_len: &mut usize,
-) -> Result<(), imp::Error> {
-    let str = aranya_capi_core::try_as_mut_slice!(str, *str_len);
-    aranya_capi_core::write_c_str(str, &channel.0, str_len)?;
-    Ok(())
-}
-
-/// Returns the bytes of `channel_id` as an array.
-///
-/// @param device ID [`ChannelId`].
-///
-// TODO: bytes param comment
-#[aranya_capi_core::no_ext_error]
-#[cfg(feature = "afc")]
-pub fn channel_id_to_bytes(channel_id: &ChannelId, bytes: &mut [u8]) {
-    let src = channel_id.0.as_array();
-    if bytes.len() >= src.len() {
-        bytes[0..src.len()].copy_from_slice(src);
-        Ok(())
-    } else {
-        Err(imp::Error::BufferTooSmall)
-    }
-}
-
 // TODO: query_device_role
 
 /// Query device's keybundle.

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -223,6 +223,23 @@ AranyaError init_team(Team *t) {
     err = aranya_create_team(&t->clients.owner.client, &t->id);
     EXPECT("error creating team", err);
 
+    // Test ID serialization and deserialization
+    size_t team_id_str_len        = ARANYA_ID_STR_LEN;
+    char *team_id_str             = malloc(team_id_str_len);
+    aranya_id_to_str(&t->id.id, team_id_str, &team_id_str_len);
+    printf("Team ID: %s \r\n", team_id_str);
+
+    AranyaId decodedId;
+    err = aranya_id_from_str(team_id_str, &decodedId);
+    EXPECT("error decoding string into an ID", err);
+
+    free(team_id_str);
+
+    if (!(memcmp(decodedId.bytes, t->id.id.bytes, ARANYA_ID_LEN) == 0)) {
+        fprintf(stderr, "application failed: Decoded ID doesn't match\r\n");
+        return EXIT_FAILURE;
+    }
+
     return ARANYA_ERROR_SUCCESS;
 }
 

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -426,7 +426,7 @@ AranyaError run(Team *t) {
         AranyaDeviceId device_result = devices[i];
         size_t device_str_len        = ARANYA_ID_STR_LEN;
         char *device_str             = malloc(ARANYA_ID_STR_LEN);
-        aranya_device_id_to_str(device_result, device_str, &device_str_len);
+        aranya_device_id_to_str(&device_result, device_str, &device_str_len);
         printf("device_id: %s at index: %zu/%zu \r\n", device_str, i,
                devices_len);
         free(device_str);

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -426,7 +426,7 @@ AranyaError run(Team *t) {
         AranyaDeviceId device_result = devices[i];
         size_t device_str_len        = ARANYA_ID_STR_LEN;
         char *device_str             = malloc(ARANYA_ID_STR_LEN);
-        aranya_device_id_to_str(&device_result, device_str, &device_str_len);
+        aranya_id_to_str(&device_result.id, device_str, &device_str_len);
         printf("device_id: %s at index: %zu/%zu \r\n", device_str, i,
                devices_len);
         free(device_str);

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -424,8 +424,8 @@ AranyaError run(Team *t) {
     }
     for (size_t i = 0; i < devices_len; i++) {
         AranyaDeviceId device_result = devices[i];
-        size_t device_str_len        = ARANYA_DEVICE_ID_STR_LEN;
-        char *device_str             = malloc(ARANYA_DEVICE_ID_STR_LEN);
+        size_t device_str_len        = ARANYA_ID_STR_LEN;
+        char *device_str             = malloc(ARANYA_ID_STR_LEN);
         aranya_device_id_to_str(device_result, device_str, &device_str_len);
         printf("device_id: %s at index: %zu/%zu \r\n", device_str, i,
                devices_len);

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -429,7 +429,18 @@ AranyaError run(Team *t) {
         aranya_id_to_str(&device_result.id, device_str, &device_str_len);
         printf("device_id: %s at index: %zu/%zu \r\n", device_str, i,
                devices_len);
+
+        AranyaId decodedId;
+        err = aranya_id_from_str(device_str, &decodedId);
+        EXPECT("error decoding string into an ID", err);
+
         free(device_str);
+
+        if (!(memcmp(decodedId.bytes, device_result.id.bytes, ARANYA_ID_LEN) == 0)) {
+            fprintf(stderr, "application failed: Decoded ID doesn't match\r\n");
+            return EXIT_FAILURE;
+        }
+
     }
 
     AranyaKeyBundle memberb_keybundle;


### PR DESCRIPTION
Closes #85

- Adds some utility methods to the C API for ID types
    - converting an ID into a string
    - converting a string into an ID
    - ~~Getting the bytes of an ID as a pointer~~ The bytes of the ID structs are accessible by their field(s)