### PR TITLE
WIP: aqc: psk keystore patch

### DIFF
--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -134,8 +134,8 @@ impl Client {
             addr = ?afc.local_addr().map_err(Error::Afc)?,
             "bound AFC router",
         );
-        debug!("getting key store info");
-        let keystore_info = daemon.get_keystore_info(context::current()).await??;
+        debug!("getting aqc psk key store info");
+        let keystore_info = daemon.get_psk_keystore_info(context::current()).await??;
         debug!("getting device id");
         let device_id = daemon.get_device_id(context::current()).await??;
         let aqc = AqcChannelsImpl::new(device_id, keystore_info).await?;
@@ -143,10 +143,10 @@ impl Client {
         Ok(Self { daemon, afc, aqc })
     }
 
-    /// Returns key store info.
-    pub async fn get_keystore_info(&self) -> Result<KeyStoreInfo> {
+    /// Returns AQC PSK key store info.
+    pub async fn get_psk_keystore_info(&self) -> Result<KeyStoreInfo> {
         self.daemon
-            .get_keystore_info(context::current())
+            .get_psk_keystore_info(context::current())
             .await?
             .map_err(Into::into)
     }
@@ -165,7 +165,7 @@ impl Client {
         let daemon = DaemonApiClient::new(tarpc::client::Config::default(), transport).spawn();
         debug!("connected to daemon");
 
-        let keystore_info = daemon.get_keystore_info(context::current()).await??;
+        let keystore_info = daemon.get_psk_keystore_info(context::current()).await??;
         debug!(?keystore_info);
         let device_id = daemon.get_device_id(context::current()).await??;
         debug!(?device_id);

--- a/crates/aranya-daemon-api/src/service.rs
+++ b/crates/aranya-daemon-api/src/service.rs
@@ -262,9 +262,9 @@ pub struct Label {
 
 #[tarpc::service]
 pub trait DaemonApi {
-    /// Gets the key store info.
-    /// The keystore can be used to pass private keys and secrets between the client and daemon.
-    async fn get_keystore_info() -> Result<KeyStoreInfo>;
+    /// Gets the AQC PSK key store info.
+    /// The keystore can be used to pass the AQC PSKs between the client and daemon.
+    async fn get_psk_keystore_info() -> Result<KeyStoreInfo>;
 
     /// Gets local address the Aranya sync server is bound to.
     async fn aranya_local_addr() -> Result<SocketAddr>;

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -80,7 +80,7 @@ impl DaemonApiServer {
         local_addr: SocketAddr,
         afc: Arc<Mutex<WriteState<api::CS, Rng>>>,
         eng: CE,
-        keystore_info: api::KeyStoreInfo,
+        psk_keystore_info: api::KeyStoreInfo,
         store: Store,
         daemon_sock: PathBuf,
         pk: Arc<PublicKeys<api::CS>>,
@@ -99,7 +99,7 @@ impl DaemonApiServer {
                 eng,
                 pk,
                 peers,
-                keystore_info,
+                psk_keystore_info,
                 afc_peers: Arc::default(),
                 afc_handler: Arc::new(Mutex::new(Handler::new(
                     device_id,
@@ -116,7 +116,7 @@ impl DaemonApiServer {
     pub fn new(
         client: Arc<Client>,
         local_addr: SocketAddr,
-        keystore_info: api::KeyStoreInfo,
+        psk_keystore_info: api::KeyStoreInfo,
         daemon_sock: PathBuf,
         pk: Arc<PublicKeys<api::CS>>,
         peers: SyncPeers,
@@ -131,7 +131,7 @@ impl DaemonApiServer {
                 local_addr,
                 pk,
                 peers,
-                keystore_info,
+                psk_keystore_info,
                 aqc_peers: Arc::default(),
             },
         })
@@ -193,8 +193,8 @@ struct DaemonApiHandler {
     pk: Arc<PublicKeys<api::CS>>,
     /// Aranya sync peers,
     peers: SyncPeers,
-    /// Key store paths.
-    keystore_info: api::KeyStoreInfo,
+    /// AQC PSK key store paths.
+    psk_keystore_info: api::KeyStoreInfo,
     /// AFC shm write.
     #[cfg(feature = "afc")]
     #[allow(dead_code)]
@@ -358,8 +358,11 @@ impl DaemonApiHandler {
 
 impl DaemonApi for DaemonApiHandler {
     #[instrument(skip(self))]
-    async fn get_keystore_info(self, context: context::Context) -> api::Result<api::KeyStoreInfo> {
-        Ok(self.keystore_info)
+    async fn get_psk_keystore_info(
+        self,
+        context: context::Context,
+    ) -> api::Result<api::KeyStoreInfo> {
+        Ok(self.psk_keystore_info)
     }
 
     #[instrument(skip(self))]

--- a/crates/aranya-daemon/src/config.rs
+++ b/crates/aranya-daemon/src/config.rs
@@ -66,6 +66,16 @@ impl Config {
         self.work_dir.join("keystore")
     }
 
+    /// Path to AQC PSK `Store`.
+    pub(crate) fn psk_keystore_path(&self) -> PathBuf {
+        self.work_dir.join("aqc_psk_keystore")
+    }
+
+    /// Path to the [`DefaultEngine`]'s AQC PSK key wrapping key.
+    pub(crate) fn psk_key_wrap_key_path(&self) -> PathBuf {
+        self.work_dir.join("psk_key_wrap_key")
+    }
+
     /// Path to the runtime's storage.
     pub(crate) fn storage_path(&self) -> PathBuf {
         self.work_dir.join("storage")

--- a/crates/aranya-daemon/src/vm_policy.rs
+++ b/crates/aranya-daemon/src/vm_policy.rs
@@ -58,7 +58,13 @@ where
     E: aranya_crypto::Engine,
 {
     /// Creates a `PolicyEngine` from a policy document.
-    pub fn new(policy_doc: &str, eng: E, store: Store, device_id: DeviceId) -> Result<Self> {
+    pub fn new(
+        policy_doc: &str,
+        eng: E,
+        store: Store,
+        aqc_psk_store: Store,
+        device_id: DeviceId,
+    ) -> Result<Self> {
         // compile the policy.
         let ast = parse_policy_document(policy_doc).context("unable to parse policy document")?;
         let module = Compiler::new(&ast)
@@ -78,7 +84,7 @@ where
         // select which FFI moddules to use.
         let ffis: Vec<Box<dyn FfiCallable<E> + Send + 'static>> = vec![
             Box::from(AfcFfi::new(store.try_clone()?)),
-            Box::from(AqcFfi::new(store.try_clone()?)),
+            Box::from(AqcFfi::new(aqc_psk_store.try_clone()?)),
             Box::from(CryptoFfi::new(store.try_clone()?)),
             Box::from(DeviceFfi::new(device_id)),
             Box::from(EnvelopeFfi),

--- a/crates/aranya-daemon/test-util/src/lib.rs
+++ b/crates/aranya-daemon/test-util/src/lib.rs
@@ -168,6 +168,11 @@ impl TestCtx {
                 fs::create_dir_all(&path)?;
                 Store::open(path)?
             };
+            let aqc_psk_store = {
+                let path = root.join("aqc_psk_keystore");
+                fs::create_dir_all(&path)?;
+                Store::open(path)?
+            };
             let (mut eng, _) = DefaultEngine::<Rng>::from_entropy(Rng);
             let bundle = KeyBundle::generate(&mut eng, &mut store)
                 .context("unable to generate `KeyBundle`")?;
@@ -189,6 +194,9 @@ impl TestCtx {
                     TEST_POLICY_1,
                     eng,
                     store.try_clone().context("unable to clone keystore")?,
+                    aqc_psk_store
+                        .try_clone()
+                        .context("unable to clone psk keystore")?,
                     bundle.device_id,
                 )?,
                 LinearStorageProvider::new(FileManager::new(&storage_dir)?),


### PR DESCRIPTION
For security purposes, use a different keystore for the AQC PSKs than the regular Aranya key bundle.