### PR TITLE
c-api: key bundle serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "aranya-util",
  "buggy",
  "libc",
+ "postcard",
  "quote",
  "syn 2.0.99",
  "thiserror 2.0.12",

--- a/crates/aranya-client-capi/Cargo.toml
+++ b/crates/aranya-client-capi/Cargo.toml
@@ -34,6 +34,7 @@ aranya-fast-channels = { workspace = true }
 buggy = { workspace = true }
 
 libc = { workspace = true, features = ["extra_traits"] }
+postcard = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -766,7 +766,7 @@ AranyaError aranya_client_init_ext(struct AranyaClient *client,
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle keybundle byte buffer `KeyBundle`.
  * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
@@ -779,7 +779,7 @@ AranyaError aranya_get_key_bundle(struct AranyaClient *client,
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle keybundle byte buffer `KeyBundle`.
  * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
@@ -1024,7 +1024,7 @@ AranyaError aranya_close_team_ext(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+ * @param keybundle serialized keybundle byte buffer `KeyBundle`.
  * @param keybundle_len is the length of the serialized keybundle.
  *
  * @relates AranyaClient.
@@ -1041,7 +1041,7 @@ AranyaError aranya_add_device_to_team(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+ * @param keybundle serialized keybundle byte buffer `KeyBundle`.
  * @param keybundle_len is the length of the serialized keybundle.
  *
  * @relates AranyaClient.
@@ -1612,7 +1612,7 @@ AranyaError aranya_id_from_str(const char *str, struct AranyaId *__output);
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle keybundle byte buffer `KeyBundle`.
  * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
@@ -1629,7 +1629,7 @@ AranyaError aranya_query_device_keybundle(struct AranyaClient *client,
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle keybundle byte buffer `KeyBundle`.
  * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -591,14 +591,40 @@ AranyaError aranya_sync_peer_config_builder_cleanup_ext(struct AranyaSyncPeerCon
                                                         struct AranyaExtError *__ext_err);
 
 /**
- * Returns serialized bytes of a key bundle.
+ * Serializes the KeyBundle and writes the bytes to the output buffer.
+ *
+ * The buffer must have enough memory allocated to it to store the serialized KeyBundle.
+ * The exact size depends on the the underlying cipher-suite.
+ * Starting with a buffer size of 256 bytes will work for the default cipher-suite.
+ *
+ * If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
+ * This gives the caller the opportunity to allocate a larger buffer and try again.
+ *
+ * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf_len returns the length of the serialized keybundle.
+ *
+ * @relates KeyBundle.
  */
 AranyaError aranya_key_bundle_serialize(const struct AranyaKeyBundle *keybundle,
                                         uint8_t *buf,
                                         size_t *buf_len);
 
 /**
- * Returns serialized bytes of a key bundle.
+ * Serializes the KeyBundle and writes the bytes to the output buffer.
+ *
+ * The buffer must have enough memory allocated to it to store the serialized KeyBundle.
+ * The exact size depends on the the underlying cipher-suite.
+ * Starting with a buffer size of 256 bytes will work for the default cipher-suite.
+ *
+ * If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
+ * This gives the caller the opportunity to allocate a larger buffer and try again.
+ *
+ * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf_len returns the length of the serialized keybundle.
+ *
+ * @relates KeyBundle.
  */
 AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybundle,
                                             uint8_t *buf,
@@ -607,6 +633,17 @@ AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybun
 
 /**
  * Converts serialized bytes into a key bundle.
+ *
+ * The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
+ * The buffer pointer and length must correspond to a valid buffer allocated by the caller.
+ *
+ * @param buf serialized keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf_len is the length of the serialized keybundle.
+ *
+ * Output params:
+ * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ *
+ * @relates KeyBundle.
  */
 AranyaError aranya_key_bundle_deserialize(uint8_t *buf,
                                           size_t buf_len,
@@ -614,6 +651,17 @@ AranyaError aranya_key_bundle_deserialize(uint8_t *buf,
 
 /**
  * Converts serialized bytes into a key bundle.
+ *
+ * The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
+ * The buffer pointer and length must correspond to a valid buffer allocated by the caller.
+ *
+ * @param buf serialized keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param buf_len is the length of the serialized keybundle.
+ *
+ * Output params:
+ * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ *
+ * @relates KeyBundle.
  */
 AranyaError aranya_key_bundle_deserialize_ext(uint8_t *buf,
                                               size_t buf_len,

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -645,7 +645,7 @@ AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybun
  *
  * @relates KeyBundle.
  */
-AranyaError aranya_key_bundle_deserialize(uint8_t *buf,
+AranyaError aranya_key_bundle_deserialize(const uint8_t *buf,
                                           size_t buf_len,
                                           struct AranyaKeyBundle *__output);
 
@@ -663,7 +663,7 @@ AranyaError aranya_key_bundle_deserialize(uint8_t *buf,
  *
  * @relates KeyBundle.
  */
-AranyaError aranya_key_bundle_deserialize_ext(uint8_t *buf,
+AranyaError aranya_key_bundle_deserialize_ext(const uint8_t *buf,
                                               size_t buf_len,
                                               struct AranyaKeyBundle *__output,
                                               struct AranyaExtError *__ext_err);

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -259,36 +259,6 @@ typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfigBuilder {
 } AranyaSyncPeerConfigBuilder;
 
 /**
- * Public Key bundle for a device.
- */
-typedef struct ARANYA_DESIGNATED_INIT AranyaKeyBundle {
-    /**
-     * Public identity key.
-     */
-    const uint8_t *ident_key;
-    /**
-     * Public identity key length.
-     */
-    size_t ident_key_len;
-    /**
-     * Public signing key.
-     */
-    const uint8_t *sign_key;
-    /**
-     * Public signing key length.
-     */
-    size_t sign_key_len;
-    /**
-     * Public encryption key.
-     */
-    const uint8_t *enc_key;
-    /**
-     * Public encryption key length.
-     */
-    size_t enc_key_len;
-} AranyaKeyBundle;
-
-/**
  * Configuration info builder for Aranya QUIC Channels.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaAqcConfigBuilder {
@@ -591,101 +561,6 @@ AranyaError aranya_sync_peer_config_builder_cleanup_ext(struct AranyaSyncPeerCon
                                                         struct AranyaExtError *__ext_err);
 
 /**
- * Serializes the KeyBundle and writes the bytes to the output buffer.
- *
- * The buffer must have enough memory allocated to it to store the serialized KeyBundle.
- * The exact size depends on the the underlying cipher-suite.
- * Starting with a buffer size of 256 bytes will work for the default cipher-suite.
- *
- * If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
- * This gives the caller the opportunity to allocate a larger buffer and try again.
- *
- * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf_len returns the length of the serialized keybundle.
- *
- * @relates KeyBundle.
- */
-AranyaError aranya_key_bundle_serialize(const struct AranyaKeyBundle *keybundle,
-                                        uint8_t *buf,
-                                        size_t *buf_len);
-
-/**
- * Serializes the KeyBundle and writes the bytes to the output buffer.
- *
- * The buffer must have enough memory allocated to it to store the serialized KeyBundle.
- * The exact size depends on the the underlying cipher-suite.
- * Starting with a buffer size of 256 bytes will work for the default cipher-suite.
- *
- * If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
- * This gives the caller the opportunity to allocate a larger buffer and try again.
- *
- * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf_len returns the length of the serialized keybundle.
- *
- * @relates KeyBundle.
- */
-AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybundle,
-                                            uint8_t *buf,
-                                            size_t *buf_len,
-                                            struct AranyaExtError *__ext_err);
-
-/**
- * Converts serialized bytes into a key bundle.
- *
- * The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
- * The buffer pointer and length must correspond to a valid buffer allocated by the caller.
- *
- * @param buf serialized keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf_len is the length of the serialized keybundle.
- *
- * Output params:
- * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- *
- * @relates KeyBundle.
- */
-AranyaError aranya_key_bundle_deserialize(const uint8_t *buf,
-                                          size_t buf_len,
-                                          struct AranyaKeyBundle *__output);
-
-/**
- * Converts serialized bytes into a key bundle.
- *
- * The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
- * The buffer pointer and length must correspond to a valid buffer allocated by the caller.
- *
- * @param buf serialized keybundle byte buffer [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- * @param buf_len is the length of the serialized keybundle.
- *
- * Output params:
- * @param keybundle KeyBundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
- *
- * @relates KeyBundle.
- */
-AranyaError aranya_key_bundle_deserialize_ext(const uint8_t *buf,
-                                              size_t buf_len,
-                                              struct AranyaKeyBundle *__output,
-                                              struct AranyaExtError *__ext_err);
-
-/**
- * Compare serialized key bundle to device key bundle
- */
-AranyaError aranya_cmp_key_bundle(struct AranyaClient *client,
-                                  const uint8_t *buf,
-                                  size_t buf_len,
-                                  bool *__output);
-
-/**
- * Compare serialized key bundle to device key bundle
- */
-AranyaError aranya_cmp_key_bundle_ext(struct AranyaClient *client,
-                                      const uint8_t *buf,
-                                      size_t buf_len,
-                                      bool *__output,
-                                      struct AranyaExtError *__ext_err);
-
-/**
  * Sets the address that the AQC server should bind to for listening.
  *
  * @param cfg a pointer to the aqc config builder
@@ -811,23 +686,25 @@ AranyaError aranya_client_init_ext(struct AranyaClient *client,
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param __output the client's key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param __output the client's key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_get_key_bundle(struct AranyaClient *client,
-                                  struct AranyaKeyBundle *__output);
+                                  uint8_t *keybundle,
+                                  size_t *keybundle_len);
 
 /**
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param __output the client's key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param __output the client's key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_get_key_bundle_ext(struct AranyaClient *client,
-                                      struct AranyaKeyBundle *__output,
+                                      uint8_t *keybundle,
+                                      size_t *keybundle_len,
                                       struct AranyaExtError *__ext_err);
 
 /**
@@ -1065,13 +942,14 @@ AranyaError aranya_close_team_ext(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keys the device's public key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param keys the device's public key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_add_device_to_team(struct AranyaClient *client,
                                       const struct AranyaTeamId *team,
-                                      const struct AranyaKeyBundle *keys);
+                                      const uint8_t *keybundle,
+                                      size_t keybundle_len);
 
 /**
  * Add a device to the team with the default role.
@@ -1080,13 +958,14 @@ AranyaError aranya_add_device_to_team(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keys the device's public key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param keys the device's public key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_add_device_to_team_ext(struct AranyaClient *client,
                                           const struct AranyaTeamId *team,
-                                          const struct AranyaKeyBundle *keys,
+                                          const uint8_t *keybundle,
+                                          size_t keybundle_len,
                                           struct AranyaExtError *__ext_err);
 
 /**
@@ -1649,14 +1528,15 @@ AranyaError aranya_id_from_str(const char *str, struct AranyaId *__output);
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param __output the device's key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param __output the device's key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_query_device_keybundle(struct AranyaClient *client,
                                           const struct AranyaTeamId *team,
                                           const struct AranyaDeviceId *device,
-                                          struct AranyaKeyBundle *__output);
+                                          uint8_t *keybundle,
+                                          size_t *keybundle_len);
 
 /**
  * Query device's keybundle.
@@ -1664,14 +1544,15 @@ AranyaError aranya_query_device_keybundle(struct AranyaClient *client,
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param __output the device's key bundle [`AranyaKeyBundle`](@ref AranyaKeyBundle).
+ * @param __output the device's key bundle [`KeyBundle`].
  *
  * @relates AranyaClient.
  */
 AranyaError aranya_query_device_keybundle_ext(struct AranyaClient *client,
                                               const struct AranyaTeamId *team,
                                               const struct AranyaDeviceId *device,
-                                              struct AranyaKeyBundle *__output,
+                                              uint8_t *keybundle,
+                                              size_t *keybundle_len,
                                               struct AranyaExtError *__ext_err);
 
 /**

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -609,14 +609,14 @@ AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybun
  * Converts serialized bytes into a key bundle.
  */
 AranyaError aranya_key_bundle_deserialize(char *buf,
-                                          size_t *buf_len,
+                                          size_t buf_len,
                                           struct AranyaKeyBundle *__output);
 
 /**
  * Converts serialized bytes into a key bundle.
  */
 AranyaError aranya_key_bundle_deserialize_ext(char *buf,
-                                              size_t *buf_len,
+                                              size_t buf_len,
                                               struct AranyaKeyBundle *__output,
                                               struct AranyaExtError *__ext_err);
 

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -686,7 +686,8 @@ AranyaError aranya_client_init_ext(struct AranyaClient *client,
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param __output the client's key bundle [`KeyBundle`].
+ * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */
@@ -698,7 +699,8 @@ AranyaError aranya_get_key_bundle(struct AranyaClient *client,
  * Gets the public key bundle for this device.
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
- * @param __output the client's key bundle [`KeyBundle`].
+ * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */
@@ -942,7 +944,8 @@ AranyaError aranya_close_team_ext(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keys the device's public key bundle [`KeyBundle`].
+ * @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len is the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */
@@ -958,7 +961,8 @@ AranyaError aranya_add_device_to_team(struct AranyaClient *client,
  *
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
- * @param keys the device's public key bundle [`KeyBundle`].
+ * @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len is the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */
@@ -1528,7 +1532,8 @@ AranyaError aranya_id_from_str(const char *str, struct AranyaId *__output);
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param __output the device's key bundle [`KeyBundle`].
+ * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */
@@ -1544,7 +1549,8 @@ AranyaError aranya_query_device_keybundle(struct AranyaClient *client,
  * @param client the Aranya Client [`AranyaClient`](@ref AranyaClient).
  * @param team the team's ID [`AranyaTeamId`](@ref AranyaTeamId).
  * @param device the device's ID [`AranyaDeviceId`](@ref AranyaDeviceId).
- * @param __output the device's key bundle [`KeyBundle`].
+ * @param keybundle keybundle byte buffer [`KeyBundle`].
+ * @param keybundle_len returns the length of the serialized keybundle.
  *
  * @relates AranyaClient.
  */

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -669,6 +669,23 @@ AranyaError aranya_key_bundle_deserialize_ext(const uint8_t *buf,
                                               struct AranyaExtError *__ext_err);
 
 /**
+ * Compare serialized key bundle to device key bundle
+ */
+AranyaError aranya_cmp_key_bundle(struct AranyaClient *client,
+                                  const uint8_t *buf,
+                                  size_t buf_len,
+                                  bool *__output);
+
+/**
+ * Compare serialized key bundle to device key bundle
+ */
+AranyaError aranya_cmp_key_bundle_ext(struct AranyaClient *client,
+                                      const uint8_t *buf,
+                                      size_t buf_len,
+                                      bool *__output,
+                                      struct AranyaExtError *__ext_err);
+
+/**
  * Sets the address that the AQC server should bind to for listening.
  *
  * @param cfg a pointer to the aqc config builder

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -185,9 +185,18 @@ enum AranyaError
      * AQC library error.
      */
     ARANYA_ERROR_AQC,
+    /**
+     * Tokio runtime error.
+     */
     ARANYA_ERROR_RUNTIME,
+    /**
+     * Invalid index error.
+     */
     ARANYA_ERROR_INVALID_INDEX,
-    ARANYA_ERROR_POSTCARD,
+    /**
+     * Serialization error.
+     */
+    ARANYA_ERROR_SERIALIZATION,
 };
 #ifndef __cplusplus
 typedef uint32_t AranyaError;

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -187,6 +187,7 @@ enum AranyaError
     ARANYA_ERROR_AQC,
     ARANYA_ERROR_RUNTIME,
     ARANYA_ERROR_INVALID_INDEX,
+    ARANYA_ERROR_POSTCARD,
 };
 #ifndef __cplusplus
 typedef uint32_t AranyaError;
@@ -258,6 +259,36 @@ typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfigBuilder {
 } AranyaSyncPeerConfigBuilder;
 
 /**
+ * Public Key bundle for a device.
+ */
+typedef struct ARANYA_DESIGNATED_INIT AranyaKeyBundle {
+    /**
+     * Public identity key.
+     */
+    const uint8_t *ident_key;
+    /**
+     * Public identity key length.
+     */
+    size_t ident_key_len;
+    /**
+     * Public signing key.
+     */
+    const uint8_t *sign_key;
+    /**
+     * Public signing key length.
+     */
+    size_t sign_key_len;
+    /**
+     * Public encryption key.
+     */
+    const uint8_t *enc_key;
+    /**
+     * Public encryption key length.
+     */
+    size_t enc_key_len;
+} AranyaKeyBundle;
+
+/**
  * Configuration info builder for Aranya QUIC Channels.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaAqcConfigBuilder {
@@ -304,36 +335,6 @@ typedef struct ARANYA_ALIGNED(8) AranyaClientConfig {
      */
     uint8_t __for_size_only[56];
 } AranyaClientConfig;
-
-/**
- * Public Key bundle for a device.
- */
-typedef struct ARANYA_DESIGNATED_INIT AranyaKeyBundle {
-    /**
-     * Public identity key.
-     */
-    const uint8_t *ident_key;
-    /**
-     * Public identity key length.
-     */
-    size_t ident_key_len;
-    /**
-     * Public signing key.
-     */
-    const uint8_t *sign_key;
-    /**
-     * Public signing key length.
-     */
-    size_t sign_key_len;
-    /**
-     * Public encryption key.
-     */
-    const uint8_t *enc_key;
-    /**
-     * Public encryption key length.
-     */
-    size_t enc_key_len;
-} AranyaKeyBundle;
 
 typedef struct AranyaId {
     uint8_t bytes[ARANYA_ID_LEN];
@@ -588,6 +589,36 @@ AranyaError aranya_sync_peer_config_builder_cleanup(struct AranyaSyncPeerConfigB
  */
 AranyaError aranya_sync_peer_config_builder_cleanup_ext(struct AranyaSyncPeerConfigBuilder *ptr,
                                                         struct AranyaExtError *__ext_err);
+
+/**
+ * Returns serialized bytes of a key bundle.
+ */
+AranyaError aranya_key_bundle_serialize(const struct AranyaKeyBundle *keybundle,
+                                        char *buf,
+                                        size_t *buf_len);
+
+/**
+ * Returns serialized bytes of a key bundle.
+ */
+AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybundle,
+                                            char *buf,
+                                            size_t *buf_len,
+                                            struct AranyaExtError *__ext_err);
+
+/**
+ * Converts serialized bytes into a key bundle.
+ */
+AranyaError aranya_key_bundle_deserialize(char *buf,
+                                          size_t *buf_len,
+                                          struct AranyaKeyBundle *__output);
+
+/**
+ * Converts serialized bytes into a key bundle.
+ */
+AranyaError aranya_key_bundle_deserialize_ext(char *buf,
+                                              size_t *buf_len,
+                                              struct AranyaKeyBundle *__output,
+                                              struct AranyaExtError *__ext_err);
 
 /**
  * Sets the address that the AQC server should bind to for listening.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -594,28 +594,28 @@ AranyaError aranya_sync_peer_config_builder_cleanup_ext(struct AranyaSyncPeerCon
  * Returns serialized bytes of a key bundle.
  */
 AranyaError aranya_key_bundle_serialize(const struct AranyaKeyBundle *keybundle,
-                                        char *buf,
+                                        uint8_t *buf,
                                         size_t *buf_len);
 
 /**
  * Returns serialized bytes of a key bundle.
  */
 AranyaError aranya_key_bundle_serialize_ext(const struct AranyaKeyBundle *keybundle,
-                                            char *buf,
+                                            uint8_t *buf,
                                             size_t *buf_len,
                                             struct AranyaExtError *__ext_err);
 
 /**
  * Converts serialized bytes into a key bundle.
  */
-AranyaError aranya_key_bundle_deserialize(char *buf,
+AranyaError aranya_key_bundle_deserialize(uint8_t *buf,
                                           size_t buf_len,
                                           struct AranyaKeyBundle *__output);
 
 /**
  * Converts serialized bytes into a key bundle.
  */
-AranyaError aranya_key_bundle_deserialize_ext(char *buf,
+AranyaError aranya_key_bundle_deserialize_ext(uint8_t *buf,
                                               size_t buf_len,
                                               struct AranyaKeyBundle *__output,
                                               struct AranyaExtError *__ext_err);

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -581,11 +581,14 @@ pub fn key_bundle_deserialize(buf: &[u8]) -> Result<KeyBundle, imp::Error> {
 
 // TODO: for testing only
 /// Compare serialized key bundle to device key bundle
-pub fn cmp_key_bundle(client: &mut Client, buf: &[u8]) -> Result<bool, imp::Error> {
-    let kb1 = get_key_bundle(client)?;
+pub unsafe fn cmp_key_bundle(client: &mut Client, buf: &[u8]) -> Result<bool, imp::Error> {
+    // SAFETY: Must trust caller provides valid keybundle.
+    let kb1 = unsafe { get_key_bundle(client)?.as_underlying() };
     debug!("{:?}", kb1);
-    let kb2 = key_bundle_deserialize(buf)?;
+    // SAFETY: Must trust caller provides valid keybundle.
+    let kb2: aranya_daemon_api::KeyBundle = unsafe { key_bundle_deserialize(buf)?.as_underlying() };
     debug!("{:?}", kb2);
+
     Ok(kb1 == kb2)
 }
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -573,9 +573,7 @@ pub unsafe fn key_bundle_serialize(
 /// @param keybundle KeyBundle [`KeyBundle`].
 ///
 /// @relates KeyBundle.
-pub fn key_bundle_deserialize(
-    buf: &[u8],
-) -> Result<KeyBundle, imp::Error> {
+pub fn key_bundle_deserialize(buf: &[u8]) -> Result<KeyBundle, imp::Error> {
     let kb = postcard::from_bytes(buf)?;
 
     Ok(KeyBundle::from_underlying(kb))

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -541,6 +541,7 @@ pub fn key_bundle_serialize(
     }
     let out = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
     for (dst, src) in out.iter_mut().zip(&data) {
+        // TODO: cast warning
         dst.write(*src as i8);
     }
     *buf_len = data.len();
@@ -558,6 +559,7 @@ pub fn key_bundle_deserialize(
     let input = aranya_capi_core::try_as_mut_slice!(buf, buf_len);
     let mut data: Vec<u8> = Vec::with_capacity(buf_len);
     for src in input.iter_mut() {
+        // TODO: cast warning
         // SAFETY: Must trust caller provides valid ptr/len.
         unsafe { data.push(src.assume_init_read() as u8) };
     }

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -65,14 +65,17 @@ pub enum Error {
     #[capi(msg = "AQC library error")]
     Aqc,
 
+    /// Tokio runtime error.
     #[capi(msg = "tokio runtime error")]
     Runtime,
 
+    /// Invalid index error.
     #[capi(msg = "invalid index")]
     InvalidIndex,
 
-    #[capi(msg = "postcard")]
-    Postcard,
+    /// Serialization error.
+    #[capi(msg = "serialization")]
+    Serialization,
 }
 
 impl From<&imp::Error> for Error {
@@ -98,7 +101,7 @@ impl From<&imp::Error> for Error {
             },
             imp::Error::Runtime(_) => Self::Runtime,
             imp::Error::InvalidIndex(_) => Self::InvalidIndex,
-            imp::Error::Postcard(_) => Self::Postcard,
+            imp::Error::Serialization(_) => Self::Serialization,
         }
     }
 }

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -552,10 +552,11 @@ pub fn key_bundle_serialize(
 // TODO: docs
 pub fn key_bundle_deserialize(
     buf: &mut MaybeUninit<c_char>,
-    buf_len: &mut usize,
+    buf_len: usize,
 ) -> Result<KeyBundle, imp::Error> {
-    let input = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
-    let mut data: Vec<u8> = Vec::with_capacity(*buf_len);
+    // TODO: try_as_slice once marked as unsafe
+    let input = aranya_capi_core::try_as_mut_slice!(buf, buf_len);
+    let mut data: Vec<u8> = Vec::with_capacity(buf_len);
     for src in input.iter_mut() {
         // SAFETY: Must trust caller provides valid ptr/len.
         unsafe { data.push(src.assume_init_read() as u8) };

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -668,7 +668,8 @@ pub unsafe fn client_init(
 /// Gets the public key bundle for this device.
 ///
 /// @param client the Aranya Client [`Client`].
-/// @param __output the client's key bundle [`KeyBundle`].
+/// @param keybundle keybundle byte buffer [`KeyBundle`].
+/// @param keybundle_len returns the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.
 pub unsafe fn get_key_bundle(
@@ -837,7 +838,8 @@ pub fn close_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error> 
 ///
 /// @param client the Aranya Client [`Client`].
 /// @param team the team's ID [`TeamId`].
-/// @param keys the device's public key bundle [`KeyBundle`].
+/// @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+/// @param keybundle_len is the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.
 pub unsafe fn add_device_to_team(
@@ -1629,7 +1631,8 @@ pub unsafe fn id_from_str(str: *const c_char) -> Result<Id, imp::Error> {
 /// @param client the Aranya Client [`Client`].
 /// @param team the team's ID [`TeamId`].
 /// @param device the device's ID [`DeviceId`].
-/// @param __output the device's key bundle [`KeyBundle`].
+/// @param keybundle keybundle byte buffer [`KeyBundle`].
+/// @param keybundle_len returns the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.
 pub unsafe fn query_device_keybundle(

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -525,18 +525,18 @@ impl KeyBundle {
 }
 
 /// Serializes the KeyBundle and writes the bytes to the output buffer.
-/// 
+///
 /// The buffer must have enough memory allocated to it to store the serialized KeyBundle.
 /// The exact size depends on the the underlying cipher-suite.
 /// Starting with a buffer size of 256 bytes will work for the default cipher-suite.
-/// 
+///
 /// If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
 /// This gives the caller the opportunity to allocate a larger buffer and try again.
-/// 
+///
 /// @param keybundle KeyBundle [`KeyBundle`].
 /// @param buf keybundle byte buffer [`KeyBundle`].
 /// @param buf_len returns the length of the serialized keybundle.
-/// 
+///
 /// @relates KeyBundle.
 pub fn key_bundle_serialize(
     keybundle: &KeyBundle,
@@ -561,16 +561,16 @@ pub fn key_bundle_serialize(
 }
 
 /// Converts serialized bytes into a key bundle.
-/// 
+///
 /// The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
 /// The buffer pointer and length must correspond to a valid buffer allocated by the caller.
-/// 
+///
 /// @param buf serialized keybundle byte buffer [`KeyBundle`].
 /// @param buf_len is the length of the serialized keybundle.
-/// 
+///
 /// Output params:
 /// @param keybundle KeyBundle [`KeyBundle`].
-/// 
+///
 /// @relates KeyBundle.
 pub fn key_bundle_deserialize(
     buf: &mut MaybeUninit<u8>,

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -479,7 +479,7 @@ impl From<Duration> for std::time::Duration {
 /// Public Key bundle for a device.
 #[repr(C)]
 #[must_use]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct KeyBundle {
     /// Public identity key.
     pub ident_key: *const u8,
@@ -577,6 +577,14 @@ pub fn key_bundle_deserialize(buf: &[u8]) -> Result<KeyBundle, imp::Error> {
     let kb = postcard::from_bytes(buf)?;
 
     Ok(KeyBundle::from_underlying(kb))
+}
+
+// TODO: for testing only
+/// Compare serialized key bundle to device key bundle
+pub fn cmp_key_bundle(client: &mut Client, buf: &[u8]) -> Result<bool, imp::Error> {
+    let kb1 = get_key_bundle(client)?;
+    let kb2 = key_bundle_deserialize(buf)?;
+    Ok(kb1 == kb2)
 }
 
 /// Configuration info for Aranya Fast Channels.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -583,7 +583,9 @@ pub fn key_bundle_deserialize(buf: &[u8]) -> Result<KeyBundle, imp::Error> {
 /// Compare serialized key bundle to device key bundle
 pub fn cmp_key_bundle(client: &mut Client, buf: &[u8]) -> Result<bool, imp::Error> {
     let kb1 = get_key_bundle(client)?;
+    debug!("{:?}", kb1);
     let kb2 = key_bundle_deserialize(buf)?;
+    debug!("{:?}", kb2);
     Ok(kb1 == kb2)
 }
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -524,8 +524,20 @@ impl KeyBundle {
     }
 }
 
-/// Returns serialized bytes of a key bundle.
-// TODO: docs
+/// Serializes the KeyBundle and writes the bytes to the output buffer.
+/// 
+/// The buffer must have enough memory allocated to it to store the serialized KeyBundle.
+/// The exact size depends on the the underlying cipher-suite.
+/// Starting with a buffer size of 256 bytes will work for the default cipher-suite.
+/// 
+/// If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
+/// This gives the caller the opportunity to allocate a larger buffer and try again.
+/// 
+/// @param keybundle KeyBundle [`KeyBundle`].
+/// @param buf keybundle byte buffer [`KeyBundle`].
+/// @param buf_len returns the length of the serialized keybundle.
+/// 
+/// @relates KeyBundle.
 pub fn key_bundle_serialize(
     keybundle: &KeyBundle,
     buf: &mut MaybeUninit<u8>,
@@ -549,7 +561,17 @@ pub fn key_bundle_serialize(
 }
 
 /// Converts serialized bytes into a key bundle.
-// TODO: docs
+/// 
+/// The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
+/// The buffer pointer and length must correspond to a valid buffer allocated by the caller.
+/// 
+/// @param buf serialized keybundle byte buffer [`KeyBundle`].
+/// @param buf_len is the length of the serialized keybundle.
+/// 
+/// Output params:
+/// @param keybundle KeyBundle [`KeyBundle`].
+/// 
+/// @relates KeyBundle.
 pub fn key_bundle_deserialize(
     buf: &mut MaybeUninit<u8>,
     buf_len: usize,

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1,4 +1,4 @@
-use core::{ffi::c_char, ops::DerefMut, ptr, slice};
+use core::{ffi::c_char, ops::DerefMut, ptr};
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use aranya_capi_core::{prelude::*, ErrorCode, InvalidArg};
@@ -476,122 +476,6 @@ impl From<Duration> for std::time::Duration {
     }
 }
 
-/// Public Key bundle for a device.
-#[repr(C)]
-#[must_use]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct KeyBundle {
-    /// Public identity key.
-    pub ident_key: *const u8,
-    /// Public identity key length.
-    pub ident_key_len: usize,
-    /// Public signing key.
-    pub sign_key: *const u8,
-    /// Public signing key length.
-    pub sign_key_len: usize,
-    /// Public encryption key.
-    pub enc_key: *const u8,
-    /// Public encryption key length.
-    pub enc_key_len: usize,
-}
-
-impl KeyBundle {
-    /// SAFETY: Must provide valid ptr/len "slices".
-    unsafe fn as_underlying(&self) -> aranya_daemon_api::KeyBundle {
-        // SAFETY: Must trust caller provides valid ptr/len.
-        unsafe {
-            aranya_daemon_api::KeyBundle {
-                identity: slice::from_raw_parts(self.ident_key, self.ident_key_len).to_vec(),
-                signing: slice::from_raw_parts(self.sign_key, self.sign_key_len).to_vec(),
-                encoding: slice::from_raw_parts(self.enc_key, self.enc_key_len).to_vec(),
-            }
-        }
-    }
-
-    fn from_underlying(keys: aranya_daemon_api::KeyBundle) -> Self {
-        // TODO: Don't leak
-        let identity = keys.identity.leak();
-        let signing = keys.signing.leak();
-        let encoding = keys.encoding.leak();
-        KeyBundle {
-            ident_key: identity.as_mut_ptr(),
-            ident_key_len: identity.len(),
-            sign_key: signing.as_mut_ptr(),
-            sign_key_len: signing.len(),
-            enc_key: encoding.as_mut_ptr(),
-            enc_key_len: encoding.len(),
-        }
-    }
-}
-
-/// Serializes the KeyBundle and writes the bytes to the output buffer.
-///
-/// The buffer must have enough memory allocated to it to store the serialized KeyBundle.
-/// The exact size depends on the the underlying cipher-suite.
-/// Starting with a buffer size of 256 bytes will work for the default cipher-suite.
-///
-/// If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
-/// This gives the caller the opportunity to allocate a larger buffer and try again.
-///
-/// @param keybundle KeyBundle [`KeyBundle`].
-/// @param buf keybundle byte buffer [`KeyBundle`].
-/// @param buf_len returns the length of the serialized keybundle.
-///
-/// @relates KeyBundle.
-pub unsafe fn key_bundle_serialize(
-    keybundle: &KeyBundle,
-    buf: *mut MaybeUninit<u8>,
-    buf_len: &mut usize,
-) -> Result<(), imp::Error> {
-    // SAFETY: Must trust caller provides valid keybundle.
-    let keybundle = unsafe { keybundle.as_underlying() };
-    let data = postcard::to_allocvec(&keybundle)?;
-
-    if *buf_len < data.len() {
-        *buf_len = data.len();
-        return Err(imp::Error::BufferTooSmall);
-    }
-    // SAFETY: Must trust caller provides valid ptr/len.
-    let out = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
-    for (dst, src) in out.iter_mut().zip(&data) {
-        dst.write(*src);
-    }
-    *buf_len = data.len();
-
-    Ok(())
-}
-
-/// Converts serialized bytes into a key bundle.
-///
-/// The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
-/// The buffer pointer and length must correspond to a valid buffer allocated by the caller.
-///
-/// @param buf serialized keybundle byte buffer [`KeyBundle`].
-/// @param buf_len is the length of the serialized keybundle.
-///
-/// Output params:
-/// @param keybundle KeyBundle [`KeyBundle`].
-///
-/// @relates KeyBundle.
-pub fn key_bundle_deserialize(buf: &[u8]) -> Result<KeyBundle, imp::Error> {
-    let kb = postcard::from_bytes(buf)?;
-
-    Ok(KeyBundle::from_underlying(kb))
-}
-
-// TODO: for testing only
-/// Compare serialized key bundle to device key bundle
-pub unsafe fn cmp_key_bundle(client: &mut Client, buf: &[u8]) -> Result<bool, imp::Error> {
-    // SAFETY: Must trust caller provides valid keybundle.
-    let kb1 = unsafe { get_key_bundle(client)?.as_underlying() };
-    debug!("{:?}", kb1);
-    // SAFETY: Must trust caller provides valid keybundle.
-    let kb2: aranya_daemon_api::KeyBundle = unsafe { key_bundle_deserialize(buf)?.as_underlying() };
-    debug!("{:?}", kb2);
-
-    Ok(kb1 == kb2)
-}
-
 /// Configuration info for Aranya Fast Channels.
 #[cfg(feature = "afc")]
 #[aranya_capi_core::opaque(size = 40, align = 8)]
@@ -787,10 +671,17 @@ pub unsafe fn client_init(
 /// @param __output the client's key bundle [`KeyBundle`].
 ///
 /// @relates AranyaClient.
-pub fn get_key_bundle(client: &mut Client) -> Result<KeyBundle, imp::Error> {
+pub unsafe fn get_key_bundle(
+    client: &mut Client,
+    keybundle: *mut MaybeUninit<u8>,
+    keybundle_len: &mut usize,
+) -> Result<(), imp::Error> {
     let client = client.deref_mut();
     let keys = client.rt.block_on(client.inner.get_key_bundle())?;
-    Ok(KeyBundle::from_underlying(keys))
+    // SAFETY: Must trust caller provides valid ptr/len for keybundle buffer.
+    unsafe { imp::key_bundle_serialize(&keys, keybundle, keybundle_len)? };
+
+    Ok(())
 }
 
 /// Gets the public device ID.
@@ -952,15 +843,14 @@ pub fn close_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error> 
 pub unsafe fn add_device_to_team(
     client: &mut Client,
     team: &TeamId,
-    keys: &KeyBundle,
+    keybundle: &[u8],
 ) -> Result<(), imp::Error> {
     let client = client.deref_mut();
-    let keys =
-        // SAFETY: Caller must provide valid keys.
-        unsafe { keys.as_underlying() };
+    let keybundle = imp::key_bundle_deserialize(keybundle)?;
+
     client
         .rt
-        .block_on(client.inner.team(team.into()).add_device_to_team(keys))?;
+        .block_on(client.inner.team(team.into()).add_device_to_team(keybundle))?;
     Ok(())
 }
 
@@ -1746,7 +1636,9 @@ pub unsafe fn query_device_keybundle(
     client: &mut Client,
     team: &TeamId,
     device: &DeviceId,
-) -> Result<KeyBundle, imp::Error> {
+    keybundle: *mut MaybeUninit<u8>,
+    keybundle_len: &mut usize,
+) -> Result<(), imp::Error> {
     let client = client.deref_mut();
     let keys = client.rt.block_on(
         client
@@ -1754,7 +1646,9 @@ pub unsafe fn query_device_keybundle(
             .queries(team.into())
             .device_keybundle(device.into()),
     )?;
-    Ok(KeyBundle::from_underlying(keys))
+    // SAFETY: Must trust caller provides valid ptr/len for keybundle buffer.
+    unsafe { imp::key_bundle_serialize(&keys, keybundle, keybundle_len)? };
+    Ok(())
 }
 
 /// Query device label assignments.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1,5 +1,5 @@
 use core::{ffi::c_char, ops::DerefMut, ptr, slice};
-use std::{ffi::OsStr, io::Read, os::unix::ffi::OsStrExt};
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use aranya_capi_core::{prelude::*, ErrorCode, InvalidArg};
 use tracing::debug;

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -667,7 +667,7 @@ pub unsafe fn client_init(
 /// Gets the public key bundle for this device.
 ///
 /// @param client the Aranya Client [`Client`].
-/// @param keybundle keybundle byte buffer [`KeyBundle`].
+/// @param keybundle keybundle byte buffer `KeyBundle`.
 /// @param keybundle_len returns the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.
@@ -837,7 +837,7 @@ pub fn close_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error> 
 ///
 /// @param client the Aranya Client [`Client`].
 /// @param team the team's ID [`TeamId`].
-/// @param keybundle serialized keybundle byte buffer [`KeyBundle`].
+/// @param keybundle serialized keybundle byte buffer `KeyBundle`.
 /// @param keybundle_len is the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.
@@ -1630,7 +1630,7 @@ pub unsafe fn id_from_str(str: *const c_char) -> Result<Id, imp::Error> {
 /// @param client the Aranya Client [`Client`].
 /// @param team the team's ID [`TeamId`].
 /// @param device the device's ID [`DeviceId`].
-/// @param keybundle keybundle byte buffer [`KeyBundle`].
+/// @param keybundle keybundle byte buffer `KeyBundle`.
 /// @param keybundle_len returns the length of the serialized keybundle.
 ///
 /// @relates AranyaClient.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -528,7 +528,7 @@ impl KeyBundle {
 // TODO: docs
 pub fn key_bundle_serialize(
     keybundle: &KeyBundle,
-    buf: &mut MaybeUninit<c_char>,
+    buf: &mut MaybeUninit<u8>,
     buf_len: &mut usize,
 ) -> Result<(), imp::Error> {
     // SAFETY: Must trust caller provides valid keybundle.
@@ -541,8 +541,7 @@ pub fn key_bundle_serialize(
     }
     let out = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
     for (dst, src) in out.iter_mut().zip(&data) {
-        // TODO: cast warning
-        dst.write(*src as i8);
+        dst.write(*src);
     }
     *buf_len = data.len();
 
@@ -552,16 +551,15 @@ pub fn key_bundle_serialize(
 /// Converts serialized bytes into a key bundle.
 // TODO: docs
 pub fn key_bundle_deserialize(
-    buf: &mut MaybeUninit<c_char>,
+    buf: &mut MaybeUninit<u8>,
     buf_len: usize,
 ) -> Result<KeyBundle, imp::Error> {
     // TODO: try_as_slice once marked as unsafe
     let input = aranya_capi_core::try_as_mut_slice!(buf, buf_len);
-    let mut data: Vec<u8> = Vec::with_capacity(buf_len);
+    let mut data = Vec::with_capacity(buf_len);
     for src in input.iter_mut() {
-        // TODO: cast warning
         // SAFETY: Must trust caller provides valid ptr/len.
-        unsafe { data.push(src.assume_init_read() as u8) };
+        unsafe { data.push(src.assume_init_read()) };
     }
     let kb = postcard::from_bytes(&data)?;
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -555,10 +555,9 @@ pub fn key_bundle_deserialize(
     buf_len: &mut usize,
 ) -> Result<KeyBundle, imp::Error> {
     let input = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
-    // TODO: don't use vec for this.
-    let mut data: Vec<u8> = Vec::new();
+    let mut data: Vec<u8> = Vec::with_capacity(*buf_len);
     for src in input.iter_mut() {
-        // SAFETY: todo
+        // SAFETY: Must trust caller provides valid ptr/len.
         unsafe { data.push(src.assume_init_read() as u8) };
     }
     let kb = postcard::from_bytes(&data)?;

--- a/crates/aranya-client-capi/src/imp/client.rs
+++ b/crates/aranya-client-capi/src/imp/client.rs
@@ -17,20 +17,7 @@ impl Typed for Client {
     const TYPE_ID: TypeId = TypeId::new(0xbbafb41c);
 }
 
-/// Serializes the KeyBundle and writes the bytes to the output buffer.
-///
-/// The buffer must have enough memory allocated to it to store the serialized KeyBundle.
-/// The exact size depends on the the underlying cipher-suite.
-/// Starting with a buffer size of 256 bytes will work for the default cipher-suite.
-///
-/// If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
-/// This gives the caller the opportunity to allocate a larger buffer and try again.
-///
-/// @param keybundle KeyBundle [`KeyBundle`].
-/// @param buf keybundle byte buffer [`KeyBundle`].
-/// @param buf_len returns the length of the serialized keybundle.
-///
-/// @relates KeyBundle.
+/// Serializes a [`KeyBundle`] into the output buffer.
 pub unsafe fn key_bundle_serialize(
     keybundle: &aranya_daemon_api::KeyBundle,
     buf: *mut MaybeUninit<u8>,
@@ -52,18 +39,7 @@ pub unsafe fn key_bundle_serialize(
     Ok(())
 }
 
-/// Converts serialized bytes into a key bundle.
-///
-/// The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
-/// The buffer pointer and length must correspond to a valid buffer allocated by the caller.
-///
-/// @param buf serialized keybundle byte buffer [`KeyBundle`].
-/// @param buf_len is the length of the serialized keybundle.
-///
-/// Output params:
-/// @param keybundle KeyBundle [`KeyBundle`].
-///
-/// @relates KeyBundle.
+/// Deserializes key bundle buffer into a [`KeyBundle`].
 pub fn key_bundle_deserialize(
     buf: &[u8],
 ) -> Result<aranya_daemon_api::KeyBundle, crate::imp::Error> {

--- a/crates/aranya-client-capi/src/imp/client.rs
+++ b/crates/aranya-client-capi/src/imp/client.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 use aranya_capi_core::safe::{TypeId, Typed};
 #[cfg(feature = "afc")]
 use aranya_client::afc;
@@ -13,4 +15,57 @@ pub struct Client {
 
 impl Typed for Client {
     const TYPE_ID: TypeId = TypeId::new(0xbbafb41c);
+}
+
+/// Serializes the KeyBundle and writes the bytes to the output buffer.
+///
+/// The buffer must have enough memory allocated to it to store the serialized KeyBundle.
+/// The exact size depends on the the underlying cipher-suite.
+/// Starting with a buffer size of 256 bytes will work for the default cipher-suite.
+///
+/// If the buffer does not have enough space, a `::ARANYA_ERROR_BUFFER_TOO_SMALL` error will be returned.
+/// This gives the caller the opportunity to allocate a larger buffer and try again.
+///
+/// @param keybundle KeyBundle [`KeyBundle`].
+/// @param buf keybundle byte buffer [`KeyBundle`].
+/// @param buf_len returns the length of the serialized keybundle.
+///
+/// @relates KeyBundle.
+pub unsafe fn key_bundle_serialize(
+    keybundle: &aranya_daemon_api::KeyBundle,
+    buf: *mut MaybeUninit<u8>,
+    buf_len: &mut usize,
+) -> Result<(), crate::imp::Error> {
+    let data = postcard::to_allocvec(&keybundle)?;
+
+    if *buf_len < data.len() {
+        *buf_len = data.len();
+        return Err(crate::imp::Error::BufferTooSmall);
+    }
+    // SAFETY: Must trust caller provides valid ptr/len.
+    let out = aranya_capi_core::try_as_mut_slice!(buf, *buf_len);
+    for (dst, src) in out.iter_mut().zip(&data) {
+        dst.write(*src);
+    }
+    *buf_len = data.len();
+
+    Ok(())
+}
+
+/// Converts serialized bytes into a key bundle.
+///
+/// The KeyBundle buffer is expected to have been serialized with `aranya_key_bundle_serialize()`.
+/// The buffer pointer and length must correspond to a valid buffer allocated by the caller.
+///
+/// @param buf serialized keybundle byte buffer [`KeyBundle`].
+/// @param buf_len is the length of the serialized keybundle.
+///
+/// Output params:
+/// @param keybundle KeyBundle [`KeyBundle`].
+///
+/// @relates KeyBundle.
+pub fn key_bundle_deserialize(
+    buf: &[u8],
+) -> Result<aranya_daemon_api::KeyBundle, crate::imp::Error> {
+    Ok(postcard::from_bytes(buf)?)
 }

--- a/crates/aranya-client-capi/src/imp/error.rs
+++ b/crates/aranya-client-capi/src/imp/error.rs
@@ -41,8 +41,8 @@ pub enum Error {
     #[error("invalid index: {0}")]
     InvalidIndex(usize),
 
-    #[error("postcard errors: {0}")]
-    Postcard(#[from] postcard::Error),
+    #[error("serialization errors: {0}")]
+    Serialization(#[from] postcard::Error),
 }
 
 impl From<WriteCStrError> for Error {

--- a/crates/aranya-client-capi/src/imp/error.rs
+++ b/crates/aranya-client-capi/src/imp/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
 
     #[error("invalid index: {0}")]
     InvalidIndex(usize),
+
+    #[error("postcard errors: {0}")]
+    Postcard(#[from] postcard::Error),
 }
 
 impl From<WriteCStrError> for Error {

--- a/crates/aranya-daemon-api/src/service.rs
+++ b/crates/aranya-daemon-api/src/service.rs
@@ -74,7 +74,7 @@ custom_id! {
 }
 
 /// A device's public key bundle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeyBundle {
     pub identity: Vec<u8>,
     pub signing: Vec<u8>,

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -219,7 +219,7 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
 
     printf("serialized key bundle into %zu bytes\r\n", buf_len);
 
-    err = aranya_key_bundle_deserialize(buf, &buf_len, &c->pk);
+    err = aranya_key_bundle_deserialize(buf, buf_len, &c->pk);
     CLIENT_EXPECT("error deserializing key bundle", c->name, err);
 
     printf("deserialized key bundle from %zu bytes\r\n", buf_len);

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -210,6 +210,20 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
     err = aranya_get_key_bundle(&c->client, &c->pk);
     CLIENT_EXPECT("error getting key bundle", c->name, err);
 
+    // test postcard serialization/deserialization of key bundle.
+    size_t buf_len = 255;
+    // TODO: uint8_t
+    char *buf = malloc(buf_len);
+    err       = aranya_key_bundle_serialize(&c->pk, buf, &buf_len);
+    CLIENT_EXPECT("error serializing key bundle", c->name, err);
+
+    printf("serialized key bundle into %zu bytes\r\n", buf_len);
+
+    err = aranya_key_bundle_deserialize(buf, &buf_len, &c->pk);
+    CLIENT_EXPECT("error deserializing key bundle", c->name, err);
+
+    printf("deserialized key bundle from %zu bytes\r\n", buf_len);
+
     return ARANYA_ERROR_SUCCESS;
 }
 

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -212,9 +212,8 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
 
     // test postcard serialization/deserialization of key bundle.
     size_t buf_len = 255;
-    // TODO: uint8_t
-    char *buf = malloc(buf_len);
-    err       = aranya_key_bundle_serialize(&c->pk, buf, &buf_len);
+    uint8_t *buf   = malloc(buf_len);
+    err            = aranya_key_bundle_serialize(&c->pk, buf, &buf_len);
     CLIENT_EXPECT("error serializing key bundle", c->name, err);
 
     printf("serialized key bundle into %zu bytes\r\n", buf_len);

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -224,10 +224,16 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
 
     printf("serialized key bundle into %zu bytes\r\n", buf_len);
 
+    bool eq;
+    err = aranya_cmp_key_bundle(&c->client, buf, buf_len, &eq);
+    CLIENT_EXPECT("error comparing key bundle", c->name, err);
+    printf("are keybundles equal? %s\r\n", eq ? "true" : "false");
+
     err = aranya_key_bundle_deserialize(buf, buf_len, &c->pk);
     CLIENT_EXPECT("error deserializing key bundle", c->name, err);
 
     printf("deserialized key bundle from %zu bytes\r\n", buf_len);
+
     free(buf);
 
     return ARANYA_ERROR_SUCCESS;

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -224,8 +224,8 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
 
     printf("serialized key bundle into %zu bytes\r\n", buf_len);
 
-    bool eq;
-    err = aranya_cmp_key_bundle(&c->client, buf, buf_len, &eq);
+    bool eq = false;
+    err     = aranya_cmp_key_bundle(&c->client, buf, buf_len, &eq);
     CLIENT_EXPECT("error comparing key bundle", c->name, err);
     printf("are keybundles equal? %s\r\n", eq ? "true" : "false");
 


### PR DESCRIPTION
Use `postcard` to serialize/deserialize key bundles.