### PR TITLE
WIP: aqc: delete chans

### DIFF
--- a/crates/aranya-daemon-api/src/service.rs
+++ b/crates/aranya-daemon-api/src/service.rs
@@ -385,9 +385,9 @@ pub trait DaemonApi {
         label_id: LabelId,
     ) -> Result<(AqcCtrl, AqcChannelInfo)>;
     /// Delete a QUIC bidi channel.
-    async fn delete_aqc_bidi_channel(chan: AqcBidiChannelId) -> Result<AqcCtrl>;
+    async fn delete_aqc_bidi_channel(key_id: BidiAuthorSecretId) -> Result<()>;
     /// Delete a QUIC uni channel.
-    async fn delete_aqc_uni_channel(chan: AqcUniChannelId) -> Result<AqcCtrl>;
+    async fn delete_aqc_uni_channel(key_id: UniAuthorSecretId) -> Result<()>;
     /// Receive AQC ctrl message.
     async fn receive_aqc_ctrl(
         team: TeamId,

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -131,6 +131,7 @@ impl Daemon {
                 DaemonApiServer::new(
                     client,
                     local_addr,
+                    eng,
                     KeyStoreInfo {
                         path: self.cfg.keystore_path(),
                         wrapped_key: self.cfg.key_wrap_key_path(),


### PR DESCRIPTION
Delete AQC channels:
- Remove the PSK encap from the keystore
- Delete the AQC PSK (this will most likely be done on a different PR since right now the PSK isn't used anywhere so it's discarded right after it's derived from the encap)
- Remove channel objects from memory
- Cleanup any networking resources associated with the QUIC channels (this will most likely be added on Ben's AQC PR)