### PR TITLE
client: Refactor Tests

### DIFF
--- a/crates/aranya-client/tests/tests.rs
+++ b/crates/aranya-client/tests/tests.rs
@@ -14,8 +14,7 @@ use std::path::Path;
 use std::{fmt, net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Context, Result};
-use aranya_client::Client;
-use aranya_client::SyncPeerConfig;
+use aranya_client::{Client, SyncPeerConfig};
 use aranya_crypto::{hash::Hash as _, rust::Sha256};
 use aranya_daemon::{
     config::{AfcConfig, Config},
@@ -35,11 +34,12 @@ use tracing::{debug, info, instrument};
 
 #[cfg(any())]
 mod afc_imports {
+    pub(super) use std::path::Path;
+
     pub(super) use aranya_client::afc::{Label, Message};
     pub(super) use aranya_daemon_api::NetIdentifier;
     pub(super) use aranya_fast_channels::Seq;
     pub(super) use buggy::BugExt as _;
-    pub(super) use std::path::Path;
 }
 #[cfg(any())]
 use afc_imports::*;

--- a/crates/aranya-client/tests/tests.rs
+++ b/crates/aranya-client/tests/tests.rs
@@ -8,30 +8,21 @@
     clippy::unwrap_used,
     rust_2018_idioms
 )]
-#[cfg(feature = "afc")]
-use std::net::Ipv4Addr;
-#[cfg(feature = "afc")]
-use std::path::Path;
+
 use std::{fmt, net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Context, Result};
-use aranya_client::client::Client;
-#[cfg(feature = "afc")]
+use aranya_client::Client;
 use aranya_client::SyncPeerConfig;
-use aranya_crypto::{hash::Hash, rust::Sha256};
+use aranya_crypto::{hash::Hash as _, rust::Sha256};
 use aranya_daemon::{
     config::{AfcConfig, Config},
     Daemon,
 };
-#[cfg(feature = "afc")]
-use aranya_daemon_api::ChanOp;
-#[cfg(feature = "afc")]
-use aranya_daemon_api::NetIdentifier;
-use aranya_daemon_api::{DeviceId, KeyBundle, Role};
-use aranya_util::addr::Addr;
-use backon::{ExponentialBuilder, Retryable};
-use spideroak_base58::ToBase58;
-use tempfile::tempdir;
+use aranya_daemon_api::{DeviceId, KeyBundle, Role, TeamId};
+use aranya_util::Addr;
+use backon::{ExponentialBuilder, Retryable as _};
+use spideroak_base58::ToBase58 as _;
 use test_log::test;
 use tokio::{
     fs,
@@ -40,6 +31,19 @@ use tokio::{
 };
 use tracing::{debug, info, instrument};
 
+#[cfg(any())]
+mod afc_imports {
+    pub(super) use aranya_client::afc::{Label, Message};
+    pub(super) use aranya_daemon_api::NetIdentifier;
+    pub(super) use aranya_fast_channels::Seq;
+    pub(super) use buggy::BugExt as _;
+    pub(super) use std::path::Path;
+}
+#[cfg(any())]
+use afc_imports::*;
+
+const SLEEP_INTERVAL: Duration = Duration::from_millis(600);
+
 #[instrument(skip_all, fields(%duration = FmtDuration(d)))]
 fn sleep(d: Duration) -> Sleep {
     debug!("sleeping");
@@ -47,24 +51,16 @@ fn sleep(d: Duration) -> Sleep {
     time::sleep(d)
 }
 
-/// Formats a [`Duration`].
-///
-/// It uses the same syntax as Go's `time.Duration`.
-pub struct FmtDuration(Duration);
+/// Formats a [`Duration`], using the same syntax as Go's `time.Duration`.
+struct FmtDuration(Duration);
 
 impl fmt::Display for FmtDuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0 < Duration::ZERO {
             write!(f, "-")?;
         }
-        // Same as
-        //    let mut d self.0.abs_diff(Duration::ZERO);
-        // but for MSRV <= 1.80.
-        let mut d = if let Some(res) = self.0.checked_sub(Duration::ZERO) {
-            res
-        } else {
-            Duration::ZERO.checked_sub(self.0).unwrap()
-        };
+
+        let mut d = self.0.abs_diff(Duration::ZERO);
 
         // Small number, format it with small units.
         if d < Duration::from_secs(1) {
@@ -75,8 +71,7 @@ impl fmt::Display for FmtDuration {
             const MICROSECOND: u128 = 1000;
             const MILLISECOND: u128 = 1000 * MICROSECOND;
 
-            // NB: the unwrap and error cases should never happen
-            // since `d` is less than one second.
+            // NB: the unwrap and error cases should never happen since `d` is less than one second.
             let ns = d.as_nanos();
             if ns < MICROSECOND {
                 return write!(f, "{ns}ns");
@@ -115,8 +110,7 @@ impl fmt::Display for FmtDuration {
         d -= Duration::from_secs(secs);
 
         if !d.is_zero() {
-            // NB: the unwrap and error cases should never happen
-            // since `d` is less than one second.
+            // NB: the unwrap and error cases should never happen since `d` is less than one second.
             let (ns, width) = trim(d.as_nanos(), 9);
             write!(f, ".{ns:0width$}")?;
         }
@@ -136,8 +130,7 @@ fn trim(mut d: u128, mut width: usize) -> (u128, usize) {
     (d, width)
 }
 
-/// Repeatedly calls `poll_data`, followed by `handle_data`, until all of the
-/// clients are pending.
+/// Repeatedly calls `poll_data`, followed by `handle_data`, until all of the clients are pending.
 // TODO(nikki): alternative to select!{} to resolve lifetime issues
 #[cfg(any())]
 macro_rules! do_poll {
@@ -174,15 +167,12 @@ struct TeamCtx {
 }
 
 impl TeamCtx {
-    pub async fn new(name: String, work_dir: PathBuf) -> Result<Self> {
-        let owner = DeviceCtx::new(name.clone(), "owner".into(), work_dir.join("owner")).await?;
-        let admin = DeviceCtx::new(name.clone(), "admin".into(), work_dir.join("admin")).await?;
-        let operator =
-            DeviceCtx::new(name.clone(), "operator".into(), work_dir.join("operator")).await?;
-        let membera =
-            DeviceCtx::new(name.clone(), "membera".into(), work_dir.join("membera")).await?;
-        let memberb =
-            DeviceCtx::new(name.clone(), "memberb".into(), work_dir.join("memberb")).await?;
+    async fn new(name: &str, work_dir: PathBuf) -> Result<Self> {
+        let owner = DeviceCtx::new(name, "owner", work_dir.join("owner")).await?;
+        let admin = DeviceCtx::new(name, "admin", work_dir.join("admin")).await?;
+        let operator = DeviceCtx::new(name, "operator", work_dir.join("operator")).await?;
+        let membera = DeviceCtx::new(name, "membera", work_dir.join("membera")).await?;
+        let memberb = DeviceCtx::new(name, "memberb", work_dir.join("memberb")).await?;
 
         Ok(Self {
             owner,
@@ -191,6 +181,80 @@ impl TeamCtx {
             membera,
             memberb,
         })
+    }
+
+    fn devices(&mut self) -> [&mut DeviceCtx; 5] {
+        [
+            &mut self.owner,
+            &mut self.admin,
+            &mut self.operator,
+            &mut self.membera,
+            &mut self.memberb,
+        ]
+    }
+
+    async fn add_all_sync_peers(&mut self, team_id: TeamId) -> Result<()> {
+        let config = SyncPeerConfig::builder().build()?;
+        let mut devices = self.devices();
+        for i in 0..devices.len() {
+            let (device, peers) = devices[i..].split_first_mut().unwrap();
+            for peer in peers {
+                device
+                    .client
+                    .team(team_id)
+                    .add_sync_peer(peer.aranya_local_addr().await?.into(), config.clone())
+                    .await?;
+                peer.client
+                    .team(team_id)
+                    .add_sync_peer(device.aranya_local_addr().await?.into(), config.clone())
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn add_all_device_roles(&mut self, team_id: TeamId) -> Result<()> {
+        // Shorthand for the teams we need to operate on.
+        let mut owner_team = self.owner.client.team(team_id);
+        let mut admin_team = self.admin.client.team(team_id);
+        let mut operator_team = self.operator.client.team(team_id);
+
+        // Add the admin as a new device, and assign its role.
+        info!("adding admin to team");
+        owner_team.add_device_to_team(self.admin.pk.clone()).await?;
+        owner_team.assign_role(self.admin.id, Role::Admin).await?;
+
+        // Make sure it sees the configuration change.
+        sleep(SLEEP_INTERVAL).await;
+
+        // Add the operator as a new device, and assign its role.
+        info!("adding operator to team");
+        owner_team
+            .add_device_to_team(self.operator.pk.clone())
+            .await?;
+        admin_team
+            .assign_role(self.operator.id, Role::Operator)
+            .await?;
+
+        // Make sure it sees the configuration change.
+        sleep(SLEEP_INTERVAL).await;
+
+        // Add member A as a new device.
+        info!("adding membera to team");
+        operator_team
+            .add_device_to_team(self.membera.pk.clone())
+            .await?;
+
+        // Add member A as a new device.
+        info!("adding memberb to team");
+        operator_team
+            .add_device_to_team(self.memberb.pk.clone())
+            .await?;
+
+        // Make sure they see the configuration change.
+        sleep(SLEEP_INTERVAL).await;
+
+        Ok(())
     }
 }
 
@@ -201,23 +265,11 @@ struct DeviceCtx {
     daemon: AbortHandle,
 }
 
-fn get_shm_path(path: String) -> String {
-    if cfg!(target_os = "macos") && path.len() > 31 {
-        // Shrink the size of the team name down to 22 bytes
-        // to work within macOS's limits.
-        let d = Sha256::hash(path.as_bytes());
-        let t: [u8; 16] = d[..16].try_into().unwrap();
-        return format!("/{}", t.to_base58());
-    };
-    path
-}
-
 impl DeviceCtx {
-    pub async fn new(team_name: String, name: String, work_dir: PathBuf) -> Result<Self> {
+    async fn new(team_name: &str, name: &str, work_dir: PathBuf) -> Result<Self> {
         fs::create_dir_all(work_dir.clone()).await?;
 
-        #[allow(unused_variables)]
-        let afc_shm_path = get_shm_path(format!("/{team_name}_{name}"));
+        let afc_shm_path = Self::get_shm_path(format!("/{team_name}_{name}"));
 
         // Setup daemon config.
         let uds_api_path = work_dir.join("uds.sock");
@@ -236,6 +288,7 @@ impl DeviceCtx {
                 max_chans,
             },
         };
+
         // Load daemon from config.
         let daemon = Daemon::load(cfg.clone())
             .await
@@ -248,8 +301,9 @@ impl DeviceCtx {
                 .expect("expected no errors running daemon")
         })
         .abort_handle();
+
         // give daemon time to setup UDS API.
-        sleep(Duration::from_millis(100)).await;
+        sleep(SLEEP_INTERVAL).await;
 
         // Initialize the user library.
         let mut client = {
@@ -266,7 +320,7 @@ impl DeviceCtx {
                 .retry(ExponentialBuilder::default())
                 .await
                 .context("unable to init client")?;
-                client.afc().set_name(name);
+                client.afc().set_name(name.to_string());
                 client
             }
             #[cfg(not(feature = "afc"))]
@@ -288,6 +342,16 @@ impl DeviceCtx {
         })
     }
 
+    fn get_shm_path(path: String) -> String {
+        if cfg!(target_os = "macos") && path.len() > 31 {
+            // Shrink the size of the team name down to 22 bytes to work within macOS's limits.
+            let d = Sha256::hash(path.as_bytes());
+            let t: [u8; 16] = d[..16].try_into().unwrap();
+            return format!("/{}", t.to_base58());
+        };
+        path
+    }
+
     async fn aranya_local_addr(&self) -> Result<SocketAddr> {
         Ok(self.client.local_addr().await?)
     }
@@ -304,15 +368,14 @@ impl Drop for DeviceCtx {
     }
 }
 
-/// Tests sync_now() by demonstrating that an admin cannot assign a role to a device until it syncs with the owner.
+/// Tests sync_now() by showing that an admin cannot assign any roles until it syncs with the owner.
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_sync_now() -> Result<()> {
-    let tmp = tempdir()?;
-    let work_dir = tmp.path().to_path_buf();
+    // Set up our team context so we can run the test.
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_sync_now", work_dir).await?;
 
-    let mut team = TeamCtx::new("test_sync_now".into(), work_dir).await?;
-
-    // create team.
+    // Create the initial team, and get our TeamId.
     let team_id = team
         .owner
         .client
@@ -321,68 +384,7 @@ async fn test_sync_now() -> Result<()> {
         .expect("expected to create team");
     info!(?team_id);
 
-    // get sync addresses.
-    let owner_addr = team.owner.aranya_local_addr().await?;
-
-    // setup team handles.
-    let mut owner_team = team.owner.client.team(team_id);
-    let mut admin_team = team.admin.client.team(team_id);
-
-    // add admin to team.
-    info!("adding admin to team");
-    owner_team.add_device_to_team(team.admin.pk.clone()).await?;
-
-    // add operator to team.
-    info!("adding operator to team");
-    owner_team
-        .add_device_to_team(team.operator.pk.clone())
-        .await?;
-
-    // Assign role to Admin
-    owner_team.assign_role(team.admin.id, Role::Admin).await?;
-
-    // Admin tries to assign a role
-    match admin_team
-        .assign_role(team.operator.id, Role::Operator)
-        .await
-    {
-        Ok(_) => bail!("Expected role assignment to fail"),
-        Err(aranya_client::Error::Daemon(_)) => {}
-        Err(_) => bail!("Unexpected error"),
-    }
-
-    // Admin syncs with the Owner peer and retries the role
-    // assignment command
-    admin_team.sync_now(owner_addr.into(), None).await?;
-    sleep(Duration::from_secs(1)).await;
-    admin_team
-        .assign_role(team.operator.id, Role::Operator)
-        .await?;
-
-    Ok(())
-}
-
-#[cfg(feature = "afc")]
-#[test(tokio::test(flavor = "multi_thread"))]
-async fn test_afc_one_way_two_chans() -> Result<()> {
-    let interval = Duration::from_millis(100);
-    let sync_config = SyncPeerConfig::builder().interval(interval).build()?;
-    let sleep_interval = interval * 6;
-
-    let tmp = tempdir()?;
-    let work_dir = tmp.path().to_path_buf();
-
-    let mut team = TeamCtx::new("test_afc_one_way_two_chans".into(), work_dir).await?;
-
-    // create team.
-    let team_id = team
-        .owner
-        .client
-        .create_team()
-        .await
-        .expect("expected to create team");
-    info!(?team_id);
-    // TODO: implement add_team.
+    // TODO(geoff): implement add_team.
     /*
     team.admin.client.add_team(team_id).await?;
     team.operator.client.add_team(team_id).await?;
@@ -390,190 +392,107 @@ async fn test_afc_one_way_two_chans() -> Result<()> {
     team.memberb.client.add_team(team_id).await?;
     */
 
-    // get sync addresses.
+    // Tell all peers to sync with one another.
+    team.add_all_sync_peers(team_id).await?;
+
+    // Grab the shorthand for our address.
     let owner_addr = team.owner.aranya_local_addr().await?;
-    let admin_addr = team.admin.aranya_local_addr().await?;
-    let operator_addr = team.operator.aranya_local_addr().await?;
-    let membera_addr = team.membera.aranya_local_addr().await?;
-    let memberb_addr = team.memberb.aranya_local_addr().await?;
 
-    // setup sync peers.
-    let mut owner_team = team.owner.client.team(team_id);
-    let mut admin_team = team.admin.client.team(team_id);
-    let mut operator_team = team.operator.client.team(team_id);
-    let mut membera_team = team.membera.client.team(team_id);
-    let mut memberb_team = team.memberb.client.team(team_id);
+    // Grab the shorthand for the teams we need to operate on.
+    let mut owner = team.owner.client.team(team_id);
+    let mut admin = team.admin.client.team(team_id);
 
-    owner_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
-
-    admin_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    admin_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    admin_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
-
-    operator_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    operator_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    operator_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
-
-    membera_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(memberb_addr.into(), sync_config.clone())
-        .await?;
-
-    memberb_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(membera_addr.into(), sync_config)
-        .await?;
-
-    // add admin to team.
+    // Add the admin as a new device, but don't give it a role.
     info!("adding admin to team");
-    owner_team.add_device_to_team(team.admin.pk.clone()).await?;
-    owner_team.assign_role(team.admin.id, Role::Admin).await?;
+    owner.add_device_to_team(team.admin.pk.clone()).await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // add operator to team.
+    // Add the operator as a new device, but don't give it a role.
     info!("adding operator to team");
-    owner_team
-        .add_device_to_team(team.operator.pk.clone())
-        .await?;
+    owner.add_device_to_team(team.operator.pk.clone()).await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    // Finally, let's give the admin its role, but don't sync with peers.
+    owner.assign_role(team.admin.id, Role::Admin).await?;
 
-    admin_team
-        .assign_role(team.operator.id, Role::Operator)
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // add membera to team.
-    info!("adding membera to team");
-    operator_team
-        .add_device_to_team(team.membera.pk.clone())
-        .await?;
-
-    // add memberb to team.
-    info!("adding memberb to team");
-    operator_team
-        .add_device_to_team(team.memberb.pk.clone())
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    #[cfg(any())]
-    {
-        // get afc addresses.
-        let membera_afc_addr = team.membera.afc_local_addr().await?;
-        let memberb_afc_addr = team.memberb.afc_local_addr().await?;
-
-        // operator assigns labels for AFC channels.
-        let label1 = Label::new(1);
-        operator_team.create_afc_label(label1).await?;
-        operator_team
-            .assign_afc_label(team.membera.id, label1)
-            .await?;
-        operator_team
-            .assign_afc_label(team.memberb.id, label1)
-            .await?;
-
-        let label2 = operator_team.create_label("label2".to_string()).await?;
-        operator_team.assign_label(team.membera.id, label2).await?;
-        operator_team.assign_label(team.memberb.id, label2).await?;
-
-        // assign network addresses.
-        operator_team
-            .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
-            .await?;
-        operator_team
-            .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
-            .await?;
+    // Now, we try to assign a role using the admin, which is expected to fail.
+    match admin.assign_role(team.operator.id, Role::Operator).await {
+        Ok(_) => bail!("Expected role assignment to fail"),
+        Err(aranya_client::Error::Daemon(_)) => {}
+        Err(_) => bail!("Unexpected error"),
     }
 
-    // get aqc addresses.
-    // TODO: use aqc_local_addr()
-    let membera_aqc_addr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-    let memberb_aqc_addr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), 1);
+    // Let's sync immediately, which will propagate the role change.
+    admin.sync_now(owner_addr.into(), None).await?;
+    sleep(Duration::from_secs(1)).await;
 
-    // TODO: use aqc addr
-    operator_team
-        .assign_aqc_net_identifier(team.membera.id, NetIdentifier(membera_aqc_addr.to_string()))
-        .await?;
-    operator_team
-        .assign_aqc_net_identifier(team.memberb.id, NetIdentifier(memberb_aqc_addr.to_string()))
-        .await?;
+    // Now we should be able to successfully assign a role.
+    admin.assign_role(team.operator.id, Role::Operator).await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    Ok(())
+}
 
-    // fact database queries
+/// Tests functionality to make sure that we can query the fact database for various things.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_query_functions() -> Result<()> {
+    // Set up our team context so we can run the test.
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_query_functions", work_dir).await?;
+
+    // Create the initial team, and get our TeamId.
+    let team_id = team
+        .owner
+        .client
+        .create_team()
+        .await
+        .expect("expected to create team");
+    info!(?team_id);
+
+    /*
+    team.admin.client.add_team(team_id).await?;
+    team.operator.client.add_team(team_id).await?;
+    team.membera.client.add_team(team_id).await?;
+    team.memberb.client.add_team(team_id).await?;
+    */
+
+    // Tell all peers to sync with one another, and assign their roles.
+    team.add_all_sync_peers(team_id).await?;
+    team.add_all_device_roles(team_id).await?;
+
+    // Test all our fact database queries.
     let mut queries = team.membera.client.queries(team_id);
+
+    // First, let's check how many devices are on the team.
     let devices = queries.devices_on_team().await?;
     assert_eq!(devices.iter().count(), 5);
     debug!("membera devices on team: {:?}", devices.iter().count());
+
+    // Check the specific role(s) a device has.
     let role = queries.device_role(team.membera.id).await?;
     assert_eq!(role, Role::Member);
     debug!("membera role: {:?}", role);
+
+    // Make sure that we have the correct keybundle.
     let keybundle = queries.device_keybundle(team.membera.id).await?;
     debug!("membera keybundle: {:?}", keybundle);
 
+    // TODO(nikki): device_label_assignments, label_exists, labels
+
+    // Now let's test any AFC-specific features. TODO(nikki): `if cfg!(feature = "afc") {`
     #[cfg(any())]
     {
-        let aqc_net_identifier = queries
-            .aqc_net_identifier(team.membera.id)
-            .await?
-            .expect("expected net identifier");
-        assert_eq!(
-            aqc_net_identifier,
-            NetIdentifier(membera_afc_addr.to_string())
-        );
+        // TODO(nikki): device_afc_label_assignments
 
-        // membera creates afc bidi channel with memberb
-        let afc_id2 = team
-            .membera
-            .client
-            .afc()
-            .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label2)
+        // Grab the shorthand for the teams we need to operate on.
+        let mut operator = team.operator.client.team(team_id);
+
+        // Grab the shorthand for the AFC address.
+        let membera_afc_addr = team.membera.afc_local_addr().await?;
+
+        // Assign a Network Identifier so that we can query for it.
+        operator
+            .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
             .await?;
 
+        // Check that it's the Network Identifier we expected.
         let afc_net_identifier = queries
             .afc_net_identifier(team.membera.id)
             .await?
@@ -584,152 +503,30 @@ async fn test_afc_one_way_two_chans() -> Result<()> {
         );
         debug!("membera afc_net_identifer: {:?}", afc_net_identifier);
 
-        debug!("membera aqc_net_identifer: {:?}", aqc_net_identifier);
-        let label_exists = queries.label_exists(label1).await?;
+        // Assign a temporary label to these devices.
+        let label1 = Label::new(1);
+        operator.create_afc_label(label1).await?;
+
+        // Check that the label we created actually exists.
+        let label_exists = queries.afc_label_exists(label1).await?;
         assert!(label_exists);
         debug!("membera label1 exists?: {:?}", label_exists);
-
-        // membera creates bidi channel with memberb
-        let afc_id1 = team
-            .membera
-            .client
-            .afc()
-            .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
-            .await?;
-
-        // membera creates bidi channel with memberb
-        let afc_id2 = team
-            .membera
-            .client
-            .afc()
-            .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label2)
-            .await?;
-
-        // wait for ctrl message to be sent.
-        sleep(Duration::from_millis(100)).await;
-
-        do_poll!(team.membera.client, team.memberb.client);
-
-        let msgs = ["hello world label1", "hello world label2"];
-
-        team.membera
-            .client
-            .afc()
-            .send_data(afc_id1, msgs[0].as_bytes())
-            .await?;
-        debug!(msg = msgs[0], "sent message");
-
-        team.membera
-            .client
-            .afc()
-            .send_data(afc_id2, msgs[1].as_bytes())
-            .await?;
-        debug!(msg = msgs[1], "sent message");
-
-        sleep(sleep_interval).await;
-        do_poll!(team.membera.client, team.memberb.client);
-
-        let got = team
-            .memberb
-            .client
-            .afc()
-            .try_recv_data()
-            .expect("should have a message");
-        let want = Message {
-            data: msgs[0].as_bytes().to_vec(),
-            // We don't know the address of outgoing connections, so
-            // assume `got.addr` is correct here.
-            address: got.address,
-            channel: afc_id1,
-            label: label1,
-            seq: Seq::ZERO,
-        };
-        assert_eq!(got, want);
-
-        let got = team
-            .memberb
-            .client
-            .afc()
-            .try_recv_data()
-            .expect("should have a message");
-        let want = Message {
-            data: msgs[1].as_bytes().to_vec(),
-            // We don't know the address of outgoing connections, so
-            // assume `got.addr` is correct here.
-            address: got.address,
-            channel: afc_id2,
-            label: label2,
-            seq: Seq::ZERO,
-        };
-        assert_eq!(got, want);
     }
 
-    let label3 = operator_team.create_label("label3".to_string()).await?;
-    let op = ChanOp::SendRecv;
-    operator_team
-        .assign_label(team.membera.id, label3, op)
-        .await?;
-    operator_team
-        .assign_label(team.memberb.id, label3, op)
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // membera creates aqc bidi channel with memberb
-    let (_aqc_id1, aqc_bidi_ctrl) = team
-        .membera
-        .client
-        .aqc()
-        .create_bidi_channel(team_id, NetIdentifier(memberb_aqc_addr.to_string()), label3)
-        .await?;
-
-    // memberb received aqc bidi channel ctrl message
-    // TODO: receiving AQC ctrl messages will happen via the network.
-    team.memberb
-        .client
-        .aqc()
-        .receive_aqc_ctrl(team_id, aqc_bidi_ctrl)
-        .await?;
-
-    // membera creates aqc uni channel with memberb
-    let (_aqc_id1, aqc_uni_ctrl) = team
-        .membera
-        .client
-        .aqc()
-        .create_uni_channel(team_id, NetIdentifier(memberb_aqc_addr.to_string()), label3)
-        .await?;
-
-    // memberb received aqc uni channel ctrl message
-    // TODO: receiving AQC ctrl messages will happen via the network.
-    team.memberb
-        .client
-        .aqc()
-        .receive_aqc_ctrl(team_id, aqc_uni_ctrl)
-        .await?;
-
-    // TODO: send AQC data.
-    operator_team.revoke_label(team.membera.id, label3).await?;
-    operator_team.revoke_label(team.memberb.id, label3).await?;
-    operator_team.delete_label(label3).await?;
+    // TODO(nikki): if cfg!(feature = "aqc") { aqc_net_identifier } and have aqc on by default.
 
     Ok(())
 }
 
-/// Tests AFC two way communication within one channel.
-#[cfg(feature = "afc")]
+// Tests to make sure that a single device can receive messages from more than one channel.
+#[cfg(any())]
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_afc_two_way_one_chan() -> Result<()> {
-    let interval = Duration::from_millis(100);
-    let sync_config = SyncPeerConfig::builder().interval(interval).build()?;
-    let sleep_interval = interval * 6;
+async fn test_afc_one_way_two_chans() -> Result<()> {
+    // Set up our team context so we can run the test.
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_afc_one_way_two_chans", work_dir).await?;
 
-    let tmp = tempdir()?;
-    let work_dir = tmp.path().to_path_buf();
-
-    let mut team = TeamCtx::new("test_afc_two_way_one_chan".into(), work_dir).await?;
-
-    // create team.
+    // Create the initial team, and get our TeamId.
     let team_id = team
         .owner
         .client
@@ -738,149 +535,319 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
         .expect("expected to create team");
     info!(?team_id);
 
-    // get sync addresses.
-    let owner_addr = team.owner.aranya_local_addr().await?;
-    let admin_addr = team.admin.aranya_local_addr().await?;
-    let operator_addr = team.operator.aranya_local_addr().await?;
-    let membera_addr = team.membera.aranya_local_addr().await?;
-    let memberb_addr = team.memberb.aranya_local_addr().await?;
+    /*
+    team.admin.client.add_team(team_id).await?;
+    team.operator.client.add_team(team_id).await?;
+    team.membera.client.add_team(team_id).await?;
+    team.memberb.client.add_team(team_id).await?;
+    */
 
-    // setup sync peers.
-    let mut owner_team = team.owner.client.team(team_id);
-    let mut admin_team = team.admin.client.team(team_id);
-    let mut operator_team = team.operator.client.team(team_id);
-    let mut membera_team = team.membera.client.team(team_id);
-    let mut memberb_team = team.memberb.client.team(team_id);
+    // Tell all peers to sync with one another, and assign their roles.
+    team.add_all_sync_peers(team_id).await?;
+    team.add_all_device_roles(team_id).await?;
 
-    owner_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
+    // Grab the shorthand for the teams we need to operate on.
+    let mut operator = team.operator.client.team(team_id);
 
-    admin_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    admin_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    admin_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
+    // Grab the shorthand for the AFC addresses.
+    let membera_afc_addr = team.membera.afc_local_addr().await?;
+    let memberb_afc_addr = team.memberb.afc_local_addr().await?;
 
-    operator_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
+    /* The operator is responsible for assigning labels for AFC channels */
+    // Create the first label so we can use it to open a channel.
+    let label1 = Label::new(1);
+    operator.create_afc_label(label1).await?;
+    operator.assign_afc_label(team.membera.id, label1).await?;
+    operator.assign_afc_label(team.memberb.id, label1).await?;
+
+    // Create the second label so we can use it to open a channel.
+    let label2 = Label::new(2);
+    operator.create_afc_label(label2).await?;
+    operator.assign_afc_label(team.membera.id, label2).await?;
+    operator.assign_afc_label(team.memberb.id, label2).await?;
+
+    // Assign Network Identifiers so peers are able to find each other.
+    operator
+        .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
         .await?;
-    operator_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    operator_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
+    operator
+        .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
         .await?;
 
-    membera_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(memberb_addr.into(), sync_config.clone())
+    // Make sure they see those changes.
+    sleep(SLEEP_INTERVAL).await;
+
+    // Create Channel 1 from Member A to Member B
+    let afc_id1 = team
+        .membera
+        .client
+        .afc()
+        .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
         .await?;
 
-    memberb_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(membera_addr.into(), sync_config)
+    // Create Channel 2 from Member A to Member B
+    let afc_id2 = team
+        .membera
+        .client
+        .afc()
+        .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label2)
         .await?;
 
-    // add admin to team.
-    info!("adding admin to team");
-    owner_team.add_device_to_team(team.admin.pk.clone()).await?;
-    owner_team.assign_role(team.admin.id, Role::Admin).await?;
+    // Make sure both clients are polling for AFC data.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    let msgs = ["hello world label1", "hello world label2"];
 
-    // add operator to team.
-    info!("adding operator to team");
-    owner_team
-        .add_device_to_team(team.operator.pk.clone())
+    // Send a message from Member A on the first channel.
+    team.membera
+        .client
+        .afc()
+        .send_data(afc_id1, msgs[0].as_bytes())
+        .await?;
+    debug!(msg = msgs[0], "sent message");
+
+    // Send another message from Member A on the second channel.
+    team.membera
+        .client
+        .afc()
+        .send_data(afc_id2, msgs[1].as_bytes())
+        .await?;
+    debug!(msg = msgs[1], "sent message");
+
+    // Make sure that Member B receives both messages.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
+
+    // Check that the first message arrived.
+    let got = team
+        .memberb
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    let want = Message {
+        data: msgs[0].as_bytes().to_vec(),
+        // TODO(nikki): We don't currently expose the address of outgoing connections, so assume
+        // `got.address` is correct here.
+        address: got.address,
+        channel: afc_id1,
+        label: label1,
+        seq: Seq::ZERO,
+    };
+    assert_eq!(got, want);
+
+    // Check that the second message arrived.
+    let got = team
+        .memberb
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    let want = Message {
+        data: msgs[1].as_bytes().to_vec(),
+        // TODO(nikki): We don't currently expose the address of outgoing connections, so assume
+        // `got.address` is correct here.
+        address: got.address,
+        channel: afc_id2,
+        label: label2,
+        seq: Seq::ZERO,
+    };
+    assert_eq!(got, want);
+
+    Ok(())
+}
+
+/// Tests to make sure that devices can talk to each other both ways across an AFC channel.
+#[cfg(any())]
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_afc_two_way_one_chan() -> Result<()> {
+    // Set up our team context so we can run the test.
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_afc_two_way_one_chan", work_dir).await?;
+
+    // Create the initial team, and get our TeamId.
+    let team_id = team
+        .owner
+        .client
+        .create_team()
+        .await
+        .expect("expected to create team");
+    info!(?team_id);
+
+    /*
+    team.admin.client.add_team(team_id).await?;
+    team.operator.client.add_team(team_id).await?;
+    team.membera.client.add_team(team_id).await?;
+    team.memberb.client.add_team(team_id).await?;
+    */
+
+    // Tell all peers to sync with one another, and assign their roles.
+    team.add_all_sync_peers(team_id).await?;
+    team.add_all_device_roles(team_id).await?;
+
+    // Grab the shorthand for the teams we need to operate on.
+    let mut operator = team.operator.client.team(team_id);
+
+    // Grab the shorthand for the AFC addresses.
+    let membera_afc_addr = team.membera.afc_local_addr().await?;
+    let memberb_afc_addr = team.memberb.afc_local_addr().await?;
+
+    /* The operator is responsible for assigning labels for AFC channels */
+    // Create a label so we're able to open a channel between members.
+    let label1 = Label::new(1);
+    operator.create_afc_label(label1).await?;
+    operator.assign_afc_label(team.membera.id, label1).await?;
+    operator.assign_afc_label(team.memberb.id, label1).await?;
+
+    // Assign Network Identifiers so peers are able to find each other.
+    operator
+        .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
+        .await?;
+    operator
+        .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
         .await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    // Make sure they see those changes.
+    sleep(SLEEP_INTERVAL).await;
 
-    admin_team
-        .assign_role(team.operator.id, Role::Operator)
+    // Create a bidirectional channel between Member A <-> Member B.
+    let afc_id1 = team
+        .membera
+        .client
+        .afc()
+        .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
         .await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    // Try sending a message from Member A.
+    let msg = "a to b";
+    team.membera
+        .client
+        .afc()
+        .send_data(afc_id1, msg.as_bytes())
+        .await?;
+    debug!(msg = msg, "sent message");
 
-    // add membera to team.
-    info!("adding membera to team");
-    operator_team
-        .add_device_to_team(team.membera.pk.clone())
+    // Make sure both peers are polling so Member B can receive the message and respond.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
+
+    // Try to receive the message from Member A.
+    let got = team
+        .memberb
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    let want = Message {
+        data: msg.as_bytes().to_vec(),
+        // TODO(nikki): We don't currently expose the address of outgoing connections, so assume
+        // `got.address` is correct here.
+        address: got.address,
+        channel: afc_id1,
+        label: label1,
+        seq: Seq::ZERO,
+    };
+    assert_eq!(got, want, "a->b");
+
+    // Try responding to Member A.
+    let msg = "b to a";
+    team.memberb
+        .client
+        .afc()
+        .send_data(afc_id1, msg.as_bytes())
+        .await?;
+    debug!(msg, "sent message");
+
+    // Sleep and make sure we're polling so we can receive the message back.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
+
+    // Check that we actually got the message.
+    let want = Message {
+        data: msg.as_bytes().to_vec(),
+        address: memberb_afc_addr,
+        channel: afc_id1,
+        label: label1,
+        seq: Seq::ZERO,
+    };
+    let got = team
+        .membera
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    assert_eq!(got, want, "b->a");
+
+    Ok(())
+}
+
+/// A positive test that sequence numbers are monotonic.
+#[cfg(any())]
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_afc_monotonic_seq() -> Result<()> {
+    // Set up our team context so we can run the test.
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_afc_monotonic_seq", work_dir).await?;
+
+    // Create the initial team, and get our TeamId.
+    let team_id = team
+        .owner
+        .client
+        .create_team()
+        .await
+        .expect("expected to create team");
+    info!(?team_id);
+
+    /*
+    team.admin.client.add_team(team_id).await?;
+    team.operator.client.add_team(team_id).await?;
+    team.membera.client.add_team(team_id).await?;
+    team.memberb.client.add_team(team_id).await?;
+    */
+
+    // Tell all peers to sync with one another, and assign their roles.
+    team.add_all_sync_peers(team_id).await?;
+    team.add_all_device_roles(team_id).await?;
+
+    // Grab the shorthand for the teams we need to operate on.
+    let mut operator = team.operator.client.team(team_id);
+
+    // Grab the shorthand for the AFC addresses.
+    let membera_afc_addr = team.membera.afc_local_addr().await?;
+    let memberb_afc_addr = team.memberb.afc_local_addr().await?;
+
+    // Create a label so our two peers can talk to each other.
+    let label1 = Label::new(1);
+    operator.create_afc_label(label1).await?;
+    operator.assign_afc_label(team.membera.id, label1).await?;
+    operator.assign_afc_label(team.memberb.id, label1).await?;
+
+    // Assign Network Identifiers so they're able to find each other.
+    operator
+        .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
+        .await?;
+    operator
+        .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
         .await?;
 
-    // add memberb to team.
-    info!("adding memberb to team");
-    operator_team
-        .add_device_to_team(team.memberb.pk.clone())
+    // Make sure they see those changes.
+    sleep(SLEEP_INTERVAL).await;
+
+    // Create a bidirectional channel between Member A <-> Member B.
+    let afc_id1 = team
+        .membera
+        .client
+        .afc()
+        .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
         .await?;
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
+    // Now let's try sending a number of messages to see if the sequence number gets iterated.
+    for i in 0..10u64 {
+        let seq = Seq::new(i);
 
-    // ==== BASIC SETUP DONE ====
-
-    // operator assigns labels for AFC channels.
-    #[cfg(any())]
-    {
-        // get afc addresses.
-        let membera_afc_addr = team.membera.afc_local_addr().await?;
-        let memberb_afc_addr = team.memberb.afc_local_addr().await?;
-
-        let label1 = Label::new(1);
-        operator_team.create_label(label1).await?;
-        operator_team.assign_label(team.membera.id, label1).await?;
-        operator_team.assign_label(team.memberb.id, label1).await?;
-
-        // assign network addresses.
-        operator_team
-            .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
-            .await?;
-        operator_team
-            .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
-            .await?;
-
-        // wait for syncing.
-        sleep(sleep_interval).await;
-
-        // membera creates bidi channel with memberb
-        let afc_id1 = team
-            .membera
-            .client
-            .afc()
-            .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
-            .await?;
-
-        let msg = "a to b";
+        // Try sending a message to Member B.
+        let msg = format!("ping {i}");
         team.membera
             .client
             .afc()
@@ -888,8 +855,11 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
             .await?;
         debug!(msg = msg, "sent message");
 
+        // Sleep and make sure that both peers are polling so we can receive the message.
+        sleep(SLEEP_INTERVAL).await;
         do_poll!(team.membera.client, team.memberb.client);
 
+        // Check that we got a message, and make sure it has the correct sequence number.
         let got = team
             .memberb
             .client
@@ -897,17 +867,18 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
             .try_recv_data()
             .expect("should have a message");
         let want = Message {
-            data: msg.as_bytes().to_vec(),
-            // We don't know the address of outgoing connections, so
-            // assume `got.addr` is correct here.
+            data: msg.into(),
+            // TODO(nikki): We don't currently expose the address of outgoing connections, so assume
+            // `got.address` is correct here.
             address: got.address,
             channel: afc_id1,
             label: label1,
-            seq: Seq::ZERO,
+            seq,
         };
         assert_eq!(got, want, "a->b");
 
-        let msg = "b to a";
+        // Reply back from Member B.
+        let msg = format!("pong {i}");
         team.memberb
             .client
             .afc()
@@ -915,15 +886,17 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
             .await?;
         debug!(msg, "sent message");
 
-        sleep(Duration::from_secs(1)).await;
+        // Sleep and make sure that both peers are polling so we can receive the message.
+        sleep(SLEEP_INTERVAL).await;
         do_poll!(team.membera.client, team.memberb.client);
 
+        // Make sure we get back the message we expect, and that it has the right sequence number.
         let want = Message {
-            data: msg.as_bytes().to_vec(),
+            data: msg.into(),
             address: memberb_afc_addr,
             channel: afc_id1,
             label: label1,
-            seq: Seq::ZERO,
+            seq,
         };
         let got = team
             .membera
@@ -937,20 +910,15 @@ async fn test_afc_two_way_one_chan() -> Result<()> {
     Ok(())
 }
 
-/// A positive test that sequence numbers are monotonic.
-#[cfg(feature = "afc")]
+/// Tests to make sure that if a daemon gets killed and reboots, it can recover all parameters
+/// needed to talk between channels.
+#[cfg(any())]
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_afc_monotonic_seq() -> Result<()> {
-    let interval = Duration::from_millis(100);
-    let sync_config = SyncPeerConfig::builder().interval(interval).build()?;
-    let sleep_interval = interval * 6;
+async fn test_afc_reboot() -> Result<()> {
+    let work_dir = tempfile::tempdir()?.path().to_path_buf();
+    let mut team = TeamCtx::new("test_afc_reboot", work_dir.clone()).await?;
 
-    let tmp = tempdir()?;
-    let work_dir = tmp.path().to_path_buf();
-
-    let mut team = TeamCtx::new("test_afc_monotonic_seq".into(), work_dir).await?;
-
-    // create team.
+    // Create the initial team, and get our TeamId.
     let team_id = team
         .owner
         .client
@@ -959,208 +927,116 @@ async fn test_afc_monotonic_seq() -> Result<()> {
         .expect("expected to create team");
     info!(?team_id);
 
-    // get sync addresses.
-    let owner_addr = team.owner.aranya_local_addr().await?;
-    let admin_addr = team.admin.aranya_local_addr().await?;
-    let operator_addr = team.operator.aranya_local_addr().await?;
-    let membera_addr = team.membera.aranya_local_addr().await?;
-    let memberb_addr = team.memberb.aranya_local_addr().await?;
+    /*
+    team.admin.client.add_team(team_id).await?;
+    team.operator.client.add_team(team_id).await?;
+    team.membera.client.add_team(team_id).await?;
+    team.memberb.client.add_team(team_id).await?;
+    */
 
-    // setup sync peers.
-    let mut owner_team = team.owner.client.team(team_id);
-    let mut admin_team = team.admin.client.team(team_id);
-    let mut operator_team = team.operator.client.team(team_id);
-    let mut membera_team = team.membera.client.team(team_id);
-    let mut memberb_team = team.memberb.client.team(team_id);
+    // Tell all peers to sync with one another, and assign their roles.
+    team.add_all_sync_peers(team_id).await?;
+    team.add_all_device_roles(team_id).await?;
 
-    owner_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    owner_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
+    // Grab the shorthand for the teams we need to operate on.
+    let mut operator = team.operator.client.team(team_id);
 
-    admin_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
+    // Grab the shorthand for the AFC addresses.
+    let membera_afc_addr = team.membera.afc_local_addr().await?;
+    let memberb_afc_addr = team.memberb.afc_local_addr().await?;
+
+    // Create a label so our two peers can talk to each other.
+    let label = Label::new(1);
+    operator.create_afc_label(label).await?;
+    operator.assign_afc_label(team.membera.id, label).await?;
+    operator.assign_afc_label(team.memberb.id, label).await?;
+
+    // Assign Network Identifiers so they're able to find each other.
+    operator
+        .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
         .await?;
-    admin_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    admin_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
+    operator
+        .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
         .await?;
 
-    operator_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    operator_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    operator_team
-        .add_sync_peer(membera_addr.into(), sync_config.clone())
-        .await?;
+    // Make sure they see those changes.
+    sleep(SLEEP_INTERVAL).await;
 
-    membera_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    membera_team
-        .add_sync_peer(memberb_addr.into(), sync_config.clone())
+    // Now, let's try killing the two daemons to simulate e.g. a crash, and reboot them.
+    drop(team.membera);
+    team.membera = DeviceCtx::new("test_afc_reboot", "membera", work_dir.join("membera")).await?;
+    drop(team.memberb);
+    team.memberb = DeviceCtx::new("test_afc_reboot", "memberb", work_dir.join("memberb")).await?;
+
+    // Try creating a new channel. This should fail if we haven't reloaded the necessary info.
+    let afc_id = team
+        .membera
+        .client
+        .afc()
+        .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label)
         .await?;
 
-    memberb_team
-        .add_sync_peer(owner_addr.into(), sync_config.clone())
+    // Try sending a message from Member A.
+    let msg = "a to b";
+    team.membera
+        .client
+        .afc()
+        .send_data(afc_id, msg.as_bytes())
         .await?;
-    memberb_team
-        .add_sync_peer(admin_addr.into(), sync_config.clone())
+    debug!(msg = msg, "sent message");
+
+    // Sleep and make sure we're polling so we can receive the message back.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
+
+    // Make sure Member B gets the correct message.
+    let got = team
+        .memberb
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    let want = Message {
+        data: msg.as_bytes().to_vec(),
+        // We don't know the address of outgoing connections, so
+        // assume `got.addr` is correct here.
+        address: got.address,
+        channel: afc_id,
+        label,
+        seq: Seq::ZERO,
+    };
+    assert_eq!(got, want, "a->b");
+
+    // Try responding to Member A.
+    let msg = "b to a";
+    team.memberb
+        .client
+        .afc()
+        .send_data(afc_id, msg.as_bytes())
         .await?;
-    memberb_team
-        .add_sync_peer(operator_addr.into(), sync_config.clone())
-        .await?;
-    memberb_team
-        .add_sync_peer(membera_addr.into(), sync_config)
-        .await?;
+    debug!(msg, "sent message");
 
-    // add admin to team.
-    info!("adding admin to team");
-    owner_team.add_device_to_team(team.admin.pk.clone()).await?;
-    owner_team.assign_role(team.admin.id, Role::Admin).await?;
+    // Sleep and make sure we're polling so we can receive the message back.
+    sleep(SLEEP_INTERVAL).await;
+    do_poll!(team.membera.client, team.memberb.client);
 
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // add operator to team.
-    info!("adding operator to team");
-    owner_team
-        .add_device_to_team(team.operator.pk.clone())
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    admin_team
-        .assign_role(team.operator.id, Role::Operator)
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // add membera to team.
-    info!("adding membera to team");
-    operator_team
-        .add_device_to_team(team.membera.pk.clone())
-        .await?;
-
-    // add memberb to team.
-    info!("adding memberb to team");
-    operator_team
-        .add_device_to_team(team.memberb.pk.clone())
-        .await?;
-
-    // wait for syncing.
-    sleep(sleep_interval).await;
-
-    // ==== BASIC SETUP DONE ====
-
-    #[cfg(any())]
-    {
-        // get afc addresses.
-        let membera_afc_addr = team.membera.afc_local_addr().await?;
-        let memberb_afc_addr = team.memberb.afc_local_addr().await?;
-
-        // operator assigns labels for AFC channels.
-        let label1 = Label::new(1);
-        operator_team.create_label(label1).await?;
-        operator_team.assign_label(team.membera.id, label1).await?;
-        operator_team.assign_label(team.memberb.id, label1).await?;
-
-        // assign network addresses.
-        operator_team
-            .assign_afc_net_identifier(team.membera.id, NetIdentifier(membera_afc_addr.to_string()))
-            .await?;
-        operator_team
-            .assign_afc_net_identifier(team.memberb.id, NetIdentifier(memberb_afc_addr.to_string()))
-            .await?;
-
-        // wait for syncing.
-        sleep(sleep_interval).await;
-
-        // membera creates bidi channel with memberb
-        let afc_id1 = team
-            .membera
-            .client
-            .afc()
-            .create_bidi_channel(team_id, NetIdentifier(memberb_afc_addr.to_string()), label1)
-            .await?;
-
-        for i in 0..10u64 {
-            let seq = Seq::new(i);
-
-            let msg = format!("ping {i}");
-            team.membera
-                .client
-                .afc()
-                .send_data(afc_id1, msg.as_bytes())
-                .await?;
-            debug!(msg = msg, "sent message");
-
-            sleep(Duration::from_secs(1)).await;
-            do_poll!(team.membera.client, team.memberb.client);
-            do_poll!(team.membera.client, team.memberb.client);
-
-            let got = team
-                .memberb
-                .client
-                .afc()
-                .try_recv_data()
-                .expect("should have a message");
-            let want = Message {
-                data: msg.into(),
-                // We don't know the address of outgoing connections,
-                // so assume `got.addr` is correct here.
-                address: got.address,
-                channel: afc_id1,
-                label: label1,
-                seq,
-            };
-            assert_eq!(got, want, "a->b");
-
-            let msg = format!("pong {i}");
-            team.memberb
-                .client
-                .afc()
-                .send_data(afc_id1, msg.as_bytes())
-                .await?;
-            debug!(msg, "sent message");
-
-            sleep(Duration::from_secs(1)).await;
-            do_poll!(team.membera.client, team.memberb.client);
-            do_poll!(team.membera.client, team.memberb.client);
-
-            let want = Message {
-                data: msg.into(),
-                address: memberb_afc_addr,
-                channel: afc_id1,
-                label: label1,
-                seq,
-            };
-            let got = team
-                .membera
-                .client
-                .afc()
-                .try_recv_data()
-                .expect("should have a message");
-            assert_eq!(got, want, "b->a");
-        }
-    }
+    // Check that we actually got the response back.
+    let want = Message {
+        data: msg.as_bytes().to_vec(),
+        address: memberb_afc_addr,
+        channel: afc_id,
+        label,
+        seq: Seq::ZERO,
+    };
+    let got = team
+        .membera
+        .client
+        .afc()
+        .try_recv_data()
+        .expect("should have a message");
+    assert_eq!(got, want, "b->a");
 
     Ok(())
 }
+
+// TODO(nikki): aqc testing variants.


### PR DESCRIPTION
Our testing suite on aranya-client has been getting majorly mangled since we stubbed out AFC and started on AQC integration. This reworks the entire tests.rs to be more modular and easier to maintain in the future (i.e. less lines, less repetition, better documentation).