### PR TITLE
C API: opaque and repr(c) cleanup

### DIFF
--- a/crates/aranya-client-capi/src/imp/config.rs
+++ b/crates/aranya-client-capi/src/imp/config.rs
@@ -41,7 +41,7 @@ pub struct ClientConfig {
     daemon_addr: *const c_char,
     #[cfg(feature = "afc")]
     afc: AfcConfig,
-    aqc: AqcConfig,
+    _aqc: AqcConfig,
 }
 
 impl ClientConfig {
@@ -110,7 +110,7 @@ impl ClientConfigBuilder {
             daemon_addr: self.daemon_addr,
             #[cfg(feature = "afc")]
             afc,
-            aqc,
+            _aqc: aqc,
         })
     }
 }
@@ -230,7 +230,7 @@ impl AfcConfigBuilder {
 /// Configuration info for Aranya Fast Channels
 pub struct AqcConfig {
     /// Address to bind AQC server to.
-    addr: *const c_char,
+    _addr: *const c_char,
 }
 
 impl Typed for AqcConfig {
@@ -261,7 +261,7 @@ impl AqcConfigBuilder {
             bug!("Tried to create an AqcConfig without a valid address!");
         }
 
-        Ok(AqcConfig { addr: self.addr })
+        Ok(AqcConfig { _addr: self.addr })
     }
 }
 

--- a/crates/aranya-client-capi/src/imp/config.rs
+++ b/crates/aranya-client-capi/src/imp/config.rs
@@ -8,7 +8,6 @@ use buggy::bug;
 
 use crate::api::defs::Duration;
 
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 /// Configuration values for syncing with a peer
 pub struct SyncPeerConfig {
@@ -36,9 +35,7 @@ impl From<&SyncPeerConfig> for aranya_client::client::SyncPeerConfig {
     }
 }
 
-#[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[aranya_capi_core::opaque(size = 40, align = 8)]
 /// Configuration info for Aranya
 pub struct ClientConfig {
     daemon_addr: *const c_char,
@@ -62,9 +59,7 @@ impl Typed for ClientConfig {
     const TYPE_ID: TypeId = TypeId::new(0x227DFC9E);
 }
 
-#[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[aranya_capi_core::opaque(size = 56, align = 8)]
 /// Builder for a [`ClientConfig`]
 pub struct ClientConfigBuilder {
     daemon_addr: *const c_char,
@@ -131,7 +126,6 @@ impl Default for ClientConfigBuilder {
     }
 }
 
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 /// Builder for a [`SyncPeerConfig`]
 pub struct SyncPeerConfigBuilder {
@@ -182,10 +176,8 @@ impl Default for SyncPeerConfigBuilder {
     }
 }
 
-#[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg(feature = "afc")]
-#[aranya_capi_core::opaque(size = 24, align = 8)]
 /// Configuration info for Aranya Fast Channels
 pub struct AfcConfig {
     /// Shared memory path.
@@ -203,7 +195,6 @@ impl Typed for AfcConfig {
 
 #[derive(Copy, Clone, Debug)]
 #[cfg(feature = "afc")]
-#[aranya_capi_core::opaque(size = 24, align = 8)]
 /// Builder for an [`AfcConfig`]
 pub struct AfcConfigBuilder {
     /// Shared memory path.
@@ -235,9 +226,7 @@ impl AfcConfigBuilder {
     }
 }
 
-#[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[aranya_capi_core::opaque(size = 24, align = 8)]
 /// Configuration info for Aranya Fast Channels
 pub struct AqcConfig {
     /// Address to bind AQC server to.
@@ -249,7 +238,6 @@ impl Typed for AqcConfig {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[aranya_capi_core::opaque(size = 24, align = 8)]
 /// Builder for an [`AqcConfig`]
 pub struct AqcConfigBuilder {
     /// Address to bind AQC server to.


### PR DESCRIPTION
Remove `aranya-capi-core::Opaque` and `repr` annotations from the types in "crates/aranya-client-capi/src/imp/config.rs"