### PR TITLE
ci: fix sync now test flake

### DIFF
--- a/crates/aranya-client/tests/tests.rs
+++ b/crates/aranya-client/tests/tests.rs
@@ -312,9 +312,6 @@ async fn test_sync_now() -> Result<()> {
     team.memberb.client.add_team(team_id).await?;
     */
 
-    // Tell all peers to sync with one another.
-    team.add_all_sync_peers(team_id).await?;
-
     // Grab the shorthand for our address.
     let owner_addr = team.owner.aranya_local_addr().await?;
 


### PR DESCRIPTION
The sync now test should test without adding sync peers so that when `sync_now` is invoked, it can prove that it caused a sync to occur.

At some point, a PR introduced adding sync peers to this test, which caused a CI flake.
Could have been one of my PRs, haven't investigated which PR introduced it yet.