### PR TITLE
rust-example: Fix Tokio Vulnerability

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -36,6 +36,6 @@ anyhow = { version = "1.0.94" }
 backon = { version = "1.3.0" }
 hex = { version = "0.4" }
 tempfile = { version = "3.14.0" }
-tokio = { version = "1.44.0", features = ["io-util", "macros", "net", "process", "sync"] }
+tokio = { version = "1.44.2", features = ["io-util", "macros", "net", "process", "sync"] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
See https://github.com/aranya-project/aranya/security/dependabot/1 for details, tokio needs to be bumped to 1.44.2. The main repo got bumped, but the example was on 1.44.1.