### PR TITLE
WIP: aqc: more robust testing

### DIFF
--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -155,7 +155,7 @@ impl Client {
     }
 
     /// Creates a client connection to the daemon.
-    #[instrument(skip_all, fields(?path))]
+    #[instrument(skip_all, fields(?path, ?aqc_addr))]
     async fn connect(path: &Path, pk: &[u8], aqc_addr: &Addr) -> Result<(Self, SocketAddr)> {
         info!("starting Aranya client");
 

--- a/crates/aranya-client/tests/aqc.rs
+++ b/crates/aranya-client/tests/aqc.rs
@@ -3,12 +3,11 @@ use std::time::Duration;
 mod common;
 use anyhow::Result;
 use aranya_client::{aqc::net::AqcChannelType, TeamConfig};
-use aranya_crypto::csprng::rand;
 use aranya_daemon_api::ChanOp;
-use buggy::BugExt;
 use bytes::Bytes;
 use common::{sleep, TeamCtx};
 use tempfile::tempdir;
+use tokio::task::JoinSet;
 use tracing::info;
 
 /// NOTE: this certificate is to be used for demonstration purposes only!
@@ -16,6 +15,14 @@ pub static CERT_PEM: &str = include_str!("../src/aqc/cert.pem");
 /// NOTE: this certificate is to be used for demonstration purposes only!
 pub static KEY_PEM: &str = include_str!("../src/aqc/key.pem");
 
+// Test AQC channels.
+//
+// Have each member device do the following in parallel:
+// 1. Create a bidirectional channel with each peer.
+// 2. Create a unidirectional channel with each peer.
+// 3. Send data over each channel that supports sending data.
+// 4. Receive data over each channel that supports receiving data.
+// 5. Delete all the channels that were created by the device.
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_aqc_chans() -> Result<()> {
     let interval = Duration::from_millis(100);
@@ -50,6 +57,9 @@ async fn test_aqc_chans() -> Result<()> {
     operator_team
         .assign_aqc_net_identifier(team.memberb.id, team.memberb.aqc_addr.clone())
         .await?;
+    operator_team
+        .assign_aqc_net_identifier(team.memberc.id, team.memberc.aqc_addr.clone())
+        .await?;
 
     // wait for syncing.
     sleep(sleep_interval).await;
@@ -59,162 +69,132 @@ async fn test_aqc_chans() -> Result<()> {
 
     let label1 = operator_team.create_label("label1".to_string()).await?;
     let op = ChanOp::SendRecv;
+    // TODO: test with different labels.
     operator_team
         .assign_label(team.membera.id, label1, op)
         .await?;
     operator_team
         .assign_label(team.memberb.id, label1, op)
         .await?;
+    operator_team
+        .assign_label(team.memberc.id, label1, op)
+        .await?;
 
     // wait for syncing.
     sleep(sleep_interval).await;
 
-    // membera creates aqc bidi channel with memberb
-    let mut bidi_chan1 = team
-        .membera
-        .client
-        .aqc()
-        .create_bidi_channel(team_id, team.memberb.aqc_addr.clone(), label1)
-        .await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    let mut set = JoinSet::new();
+    let membera_peers = [team.memberb.aqc_addr.clone(), team.memberc.aqc_addr.clone()];
+    let memberb_peers = [team.membera.aqc_addr.clone(), team.memberc.aqc_addr.clone()];
+    let memberc_peers = [team.membera.aqc_addr.clone(), team.memberb.aqc_addr.clone()];
+    let mut devices = Vec::new();
+    devices.push(team.membera);
+    devices.push(team.memberb);
+    devices.push(team.memberc);
 
-    let channel_type = team
-        .memberb
-        .client
-        .aqc()
-        .receive_channel()
-        .await
-        .assume("channel must exist")?;
-    let mut bidi_chan2 = match channel_type {
-        AqcChannelType::Bidirectional { channel } => channel,
-        _ => {
-            buggy::bug!("Expected a bidirectional channel")
-        }
-    };
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let mut send1_1 = bidi_chan1.create_unidirectional_stream().await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    let peers = [membera_peers, memberb_peers, memberc_peers];
+    for i in 0..devices.len() {
+        let mut device = devices.pop().expect("expected a device");
+        let peers = peers[i].clone();
+        set.spawn(async move {
+            let mut bidi_chans = Vec::new();
+            let mut uni_chans = Vec::new();
+            for peer in peers {
+                // create bidirectional channels with each peer.
+                let bidi = device.client.aqc().create_bidi_channel(team_id, peer.clone(), label1).await.expect("expected to create bidi chan");
+                bidi_chans.push(bidi);
 
-    // Test sending streams
+                // create unidirectional channels with each peer.
+                let uni = device.client.aqc().create_uni_channel(team_id, peer, label1).await.expect("expected to create bidi chan");
+                uni_chans.push(uni);
+            }
 
-    // Send from 1 to 2 with a unidirectional stream
-    let msg1 = Bytes::from("hello");
-    send1_1.send(&msg1).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    // Receive a unidirectional stream from peer 1
-    let (maybe_send2_1, mut recv2_1) = bidi_chan2
-        .receive_stream()
-        .await
-        .assume("stream not received")?;
-    assert!(maybe_send2_1.is_none(), "Expected unidirectional stream");
-    tokio::time::sleep(Duration::from_millis(100)).await;
+            // Receive any channels that were created.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let mut recv_chans = Vec::new();
+            while let Some(recv_chan) = device.client.aqc().receive_channel().await {
+                recv_chans.push(recv_chan);
+            }
 
-    let mut target = vec![0u8; 1024 * 1024 * 2];
-    let len = recv2_1
-        .receive(target.as_mut_slice())
-        .await?
-        .assume("no data received")?;
-    assert_eq!(&target[..len], b"hello");
+            // Send data over all created channels that support send.
+            // TODO: test create_bidirectional_stream()
+            for bidi in &mut bidi_chans {
+                let mut send = bidi.create_unidirectional_stream().await.expect("expected to create uni stream");
+                let msg = Bytes::from("hello");
+                send.send(&msg).await.expect("expected to send data");
+            }
+            for uni in &mut uni_chans {
+                let mut send = uni.create_unidirectional_stream().await.expect("expected to create uni stream");
+                let msg = Bytes::from("hello");
+                send.send(&msg).await.expect("expected to send data");
+            }
 
-    let (mut send1_2, mut recv1_2) = bidi_chan1.create_bidirectional_stream().await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    // Send from 1 to 2 with a bidirectional stream
-    let msg2 = Bytes::from("hello2");
-    send1_2.send(&msg2).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let (maybe_send2_2, mut recv2_2) = bidi_chan2
-        .receive_stream()
-        .await
-        .assume("stream not received")?;
-    let mut send2_2 = maybe_send2_2.expect("Expected bidirectional stream");
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let mut target = vec![0u8; 1024 * 1024 * 2];
-    let len = recv2_2
-        .receive(target.as_mut_slice())
-        .await?
-        .assume("no data received")?;
-    assert_eq!(&target[..len], b"hello2");
-    // Send from 2 to 1 with a bidirectional stream
-    let msg3 = Bytes::from("hello3");
-    send2_2.send(&msg3).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let mut target = vec![0u8; 1024 * 1024 * 2];
-    let len = recv1_2
-        .receive(target.as_mut_slice())
-        .await?
-        .assume("no data received")?;
-    assert_eq!(&target[..len], b"hello3");
+            // Send data over all received channels that support send.
+            // TODO: test sending larger messages.
+            // TODO: send different data over each channel.
+            for uni in &mut recv_chans {
+                let mut send = match uni {
+                    AqcChannelType::Sender { ref mut sender } => { 
+                        sender.create_unidirectional_stream().await.expect("expected to create uni stream")
+                    },
+                    AqcChannelType::Receiver { .. } => { continue },
+                    AqcChannelType::Bidirectional { ref mut channel } => {
+                        channel.create_unidirectional_stream().await.expect("expected to create uni stream")
+                    },
+                };
+                let msg = Bytes::from("hello");
+                send.send(&msg).await.expect("expected to send data");
+            }
 
-    // Test sending a large message
-    let big_data = {
-        let mut rng = rand::thread_rng();
-        let mut data = vec![0u8; 1024 * 1024 * 3 / 2];
-        rand::Rng::fill(&mut rng, &mut data[..]);
-        Bytes::from(data)
-    };
+            // Receive data over all created and received channels that support receiving data.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            for bidi in &mut bidi_chans {
+                while let Some((_send, mut recv)) = bidi.receive_stream().await {
+                    let mut buf = vec![0u8; 1024 * 1024 * 2];
+                    let len = recv
+                        .receive(buf.as_mut_slice())
+                        .await.expect("expected to receive data")
+                        .expect("no data received");
+                    assert_eq!(&buf[..len], b"hello");
+                }
+            }
+            for uni in &mut recv_chans {
+                let mut streams = Vec::new();
+                match uni {
+                    AqcChannelType::Sender { .. } => { continue },
+                    AqcChannelType::Receiver { ref mut receiver } => {
+                        while let Some(recv) = receiver.receive_unidirectional_stream().await.expect("expected no error") {
+                            streams.push(recv);
+                        }
+                    },
+                    AqcChannelType::Bidirectional { ref mut channel } => {
+                        while let Some((_send, recv)) = channel.receive_stream().await {
+                            streams.push(recv);
+                        }
+                    },
+                };
+                for mut recv in streams {
+                    let mut buf = vec![0u8; 1024 * 1024 * 2];
+                    let len = recv
+                        .receive(buf.as_mut_slice())
+                        .await.expect("expected to receive data")
+                        .expect("no data received");
+                    assert_eq!(&buf[..len], b"hello");
+                }
+            }
 
-    send1_2.send(&big_data).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let mut total_len: usize = 0;
-    let mut total_pieces: i32 = 0;
-    // Send stream should return the message in pieces
-    while let Some(len) = recv2_2.receive(&mut target[total_len..]).await? {
-        total_pieces = total_pieces.checked_add(1).expect("Pieces overflow");
-        total_len = total_len.checked_add(len).expect("Length overflow");
-        if total_len >= big_data.len() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
+            // Delete all channels created by the device.
+            for bidi in &mut bidi_chans {
+                bidi.close().expect("expected to close bidi channel");
+            }
+            for uni in &mut uni_chans {
+                uni.close().expect("expected to close uni chan");
+            }
+
+            // TODO: verify total messages send/received.
+        });
     }
-    assert!(total_pieces > 1);
-    assert_eq!(total_len, big_data.len());
-    assert_eq!(&target[..total_len], &big_data[..]);
+    set.join_all().await;
 
-    bidi_chan1.close()?;
-    bidi_chan2.close()?;
-    // membera creates aqc uni channel with memberb
-    let mut uni_chan1 = team
-        .membera
-        .client
-        .aqc()
-        .create_uni_channel(team_id, team.memberb.aqc_addr.clone(), label1)
-        .await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let channel_type = team
-        .memberb
-        .client
-        .aqc()
-        .receive_channel()
-        .await
-        .assume("channel must exist")?;
-    let mut uni_chan2 = match channel_type {
-        AqcChannelType::Receiver { receiver } => receiver,
-        _ => {
-            buggy::bug!("Expected a unidirectional channel")
-        }
-    };
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let mut send1_1 = uni_chan1.create_unidirectional_stream().await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    // Test sending streams
-
-    // Send from 1 to 2 with a unidirectional stream
-    let msg1 = Bytes::from("hello");
-    send1_1.send(&msg1).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let mut recv2_1 = uni_chan2
-        .receive_unidirectional_stream()
-        .await
-        .assume("stream not received")?
-        .assume("stream not received")?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let mut target = vec![0u8; 1024 * 1024 * 2];
-    let len = recv2_1
-        .receive(target.as_mut_slice())
-        .await?
-        .assume("no data received")?;
-    assert_eq!(&target[..len], b"hello");
     Ok(())
 }

--- a/crates/aranya-client/tests/common/mod.rs
+++ b/crates/aranya-client/tests/common/mod.rs
@@ -110,6 +110,7 @@ pub struct TeamCtx {
     pub operator: DeviceCtx,
     pub membera: DeviceCtx,
     pub memberb: DeviceCtx,
+    pub memberc: DeviceCtx,
 }
 
 impl TeamCtx {
@@ -117,8 +118,10 @@ impl TeamCtx {
         let owner = DeviceCtx::new(name, "owner", work_dir.join("owner"), 9001).await?;
         let admin = DeviceCtx::new(name, "admin", work_dir.join("admin"), 9002).await?;
         let operator = DeviceCtx::new(name, "operator", work_dir.join("operator"), 9003).await?;
+        // TODO: support setting up tests with a variable number of devices with the member role.
         let membera = DeviceCtx::new(name, "membera", work_dir.join("membera"), 9004).await?;
         let memberb = DeviceCtx::new(name, "memberb", work_dir.join("memberb"), 9005).await?;
+        let memberc = DeviceCtx::new(name, "memberc", work_dir.join("memberc"), 9006).await?;
 
         Ok(Self {
             owner,
@@ -126,16 +129,18 @@ impl TeamCtx {
             operator,
             membera,
             memberb,
+            memberc,
         })
     }
 
-    fn devices(&mut self) -> [&mut DeviceCtx; 5] {
+    fn devices(&mut self) -> [&mut DeviceCtx; 6] {
         [
             &mut self.owner,
             &mut self.admin,
             &mut self.operator,
             &mut self.membera,
             &mut self.memberb,
+            &mut self.memberc,
         ]
     }
 
@@ -196,10 +201,16 @@ impl TeamCtx {
             .add_device_to_team(self.membera.pk.clone())
             .await?;
 
-        // Add member A as a new device.
+        // Add member B as a new device.
         info!("adding memberb to team");
         operator_team
             .add_device_to_team(self.memberb.pk.clone())
+            .await?;
+
+        // Add member C as a new device.
+        info!("adding memberc to team");
+        operator_team
+            .add_device_to_team(self.memberc.pk.clone())
             .await?;
 
         // Make sure they see the configuration change.


### PR DESCRIPTION
Adds more robust testing of AQC.
Creates/deletes multiple channels and sends/receives data in parallel.

Have each member device do the following in parallel:
1. Create a bidirectional channel with each peer.
2. Create a unidirectional channel with each peer.
3. Send data over each channel that supports sending data.
4. Receive data over each channel that supports receiving data.
5. Delete all the channels that were created by the device.