### PR TITLE
aqc: pair PSKs with cipher suites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,8 +120,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 [[package]]
 name = "aranya-aqc-util"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecb1a7d1a4e0052f2e6a84daf013f64292dbde2225b4a23d298ab7c6842962e"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -136,8 +135,7 @@ dependencies = [
 [[package]]
 name = "aranya-capi-codegen"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7482a25508d9c6315a97acd08f62528552deb011835311e53651e525ae967cb7"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -154,8 +152,7 @@ dependencies = [
 [[package]]
 name = "aranya-capi-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f57f8686eff6ff7d3052167b71a0316f6b1a86d8a1f5bb61065160648fc0ce"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -169,8 +166,7 @@ dependencies = [
 [[package]]
 name = "aranya-capi-macro"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c97a7ee1b24b93873230d68acaa4410574a53b009f93bb1776b3d62c73d960f"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",
@@ -223,8 +219,7 @@ dependencies = [
 [[package]]
 name = "aranya-crypto"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e19bd18f91c86681abafb6fd4d33e13ab1462732506f3f8572b6c829ddc604f"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "buggy",
  "byteorder",
@@ -239,13 +234,13 @@ dependencies = [
  "spideroak-base58",
  "spideroak-crypto",
  "thiserror 2.0.12",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "aranya-crypto-ffi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e8952076d6d27bfe18788e0f0071852a7112dfb616845d93580c1d231ac652"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -323,8 +318,7 @@ dependencies = [
 [[package]]
 name = "aranya-device-ffi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e29e195e269b55d3f4c98ac137150123fe8c672da36a35affd799d8c115b81"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -333,8 +327,7 @@ dependencies = [
 [[package]]
 name = "aranya-envelope-ffi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65bdb44fdd0f61d8e42109b8f8afc17b01f03479d56775c36766cbe8bb91095"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -345,8 +338,7 @@ dependencies = [
 [[package]]
 name = "aranya-fast-channels"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeb9a850d354b99fa5c460119dfd1f6430ce20d9f11eb215b78d8283f117af6"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "buggy",
@@ -362,8 +354,7 @@ dependencies = [
 [[package]]
 name = "aranya-idam-ffi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60958065407d2d8fa0f07005d9dc113b336a1961b31c7939d5698ec30dcaf330"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -384,8 +375,7 @@ dependencies = [
 [[package]]
 name = "aranya-libc"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3fc92aad8cb2e51fdd17dfa4dd51c3e39da8d22bacfc59527b491740c328c"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -397,8 +387,7 @@ dependencies = [
 [[package]]
 name = "aranya-perspective-ffi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c530731494d4e19445ed7667ce689eab31a221bbe6dd36bd0d6d999611d69ae"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -407,8 +396,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-ast"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3e426ebe678b951d24166496be091abb185618267b8518c2b7e4c67903b010"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -417,8 +405,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-compiler"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ad002df786230ef36a9409792610b7ccab5ff362eac555e778f3a15ef98d8c"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-policy-ast",
  "aranya-policy-lang",
@@ -432,8 +419,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dee310dbf9e5f60688d1e6a847a5da8e39a52a7ecf9f36a9e2c7a1fcc25503b"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -445,8 +431,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-ifgen"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b9b0b9f9bc74ae1f518721499107241ed6c2fd4533fbecf11bcc39604f4765"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-policy-ifgen-macro",
  "aranya-policy-vm",
@@ -458,8 +443,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-ifgen-build"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270551af0e503d605ac6ea5449ea90f0dbcc564c502c981d98d922af4bbd5203"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -473,8 +457,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-ifgen-macro"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125121393e4bdc97794f3e472000a9f0e5db126af2703ea298debc9b98e8ad55"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,8 +467,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-lang"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3b81ecba74dd8f727f08dcda5fd637355e4213340ed23dbe7679d73c13625f"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -501,8 +483,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-module"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203184cdae36b30647955b8b899534f24fb069d1567077ba5782dd405cb2358e"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -513,8 +494,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-vm"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e2265b29ed11c9684521e7bd60736939d89c393df49cdb3305953584929af1"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -529,8 +509,7 @@ dependencies = [
 [[package]]
 name = "aranya-runtime"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc634876c5310e7b57c4d1c47052e0546574db958abbf2ea92e037891344876"
+source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",
@@ -1041,7 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1739,7 +1718,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1954,7 +1933,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2353,7 +2332,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2775,7 +2754,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2912,7 +2891,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2920,6 +2908,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,8 +119,9 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "aranya-aqc-util"
-version = "0.2.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d291de74f60cae019937c367fddb9cb346e5c1ed7cff6ec5e3365deca947d529"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -134,8 +135,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-codegen"
-version = "0.2.3"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c6a8610e1e6fc38f3e10a92e7ae38c83f92a7c80385f722525910afc6080e1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -151,22 +153,25 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.3.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf870dbd37bc86da3d02a0c9100c31815e44de98a01eb29bbb4bc4236d616417"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
  "buggy",
  "cfg-if",
  "const_format",
+ "elain",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "aranya-capi-macro"
-version = "0.2.2"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433219c4d1025a94a5d333b209d1354108835f9fa7d676a6dd77bd054653a2fe"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",
@@ -218,8 +223,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto"
-version = "0.5.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef7649eb26ccaac46800248d215e374f752083723754e5f24e261a7bdc2dd34"
 dependencies = [
  "buggy",
  "byteorder",
@@ -239,8 +245,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c0fa18d13d51c19ba91f8a1d0a9d1fd59c15e13d15de8c7ca33ef5f92ef3f3"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -317,8 +324,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-device-ffi"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58648b91ca88bc915845fee343cf2ded72ef791644181d023a61f9de62400bd9"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -326,8 +334,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-envelope-ffi"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec8a8cda87e1a31288eb9b6118f13dadff6834634dcc13d4fcdabd1dd3d79c9"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -337,8 +346,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.6.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92381ca0694401c40f95d0441be52e70100dd1c1c30b444c87829b7093281de2"
 dependencies = [
  "aranya-crypto",
  "buggy",
@@ -353,8 +363,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-idam-ffi"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95947d51b165789a15b1f7a46dc3975a28b1e7199335fe836cd660005e0f9180"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -375,7 +386,8 @@ dependencies = [
 [[package]]
 name = "aranya-libc"
 version = "0.2.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d3fc92aad8cb2e51fdd17dfa4dd51c3e39da8d22bacfc59527b491740c328c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -386,8 +398,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-perspective-ffi"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ba2898c3679c964e6c858b0b340d2ee5122671af70b14cd20bfd7247eef2a3"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -395,8 +408,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ast"
-version = "0.4.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4c33e8ab519a5ae145a642f92851c811aa8411622540a32056796a652676ba"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -404,8 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca76166e6583aafb0cc8cdd8c38bbc7e66f0fb4fc3bbc82d7cc76ebe5e38461"
 dependencies = [
  "aranya-policy-ast",
  "aranya-policy-lang",
@@ -418,8 +433,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-derive"
-version = "0.5.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69603f3de7156f0436e61f462a4ed453cc8354df044abfdb4290703c68116d21"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -430,8 +446,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d053c44a2fb7697971b6492100ef53590868e4f087c14a487ad7f7edffe85c"
 dependencies = [
  "aranya-policy-ifgen-macro",
  "aranya-policy-vm",
@@ -442,8 +459,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-build"
-version = "0.4.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a63a5c52567b89c08dff9268e6baa26bf7f0b256407084935a8af8a5761f5f4"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -457,7 +475,8 @@ dependencies = [
 [[package]]
 name = "aranya-policy-ifgen-macro"
 version = "0.3.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125121393e4bdc97794f3e472000a9f0e5db126af2703ea298debc9b98e8ad55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -466,8 +485,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-lang"
-version = "0.4.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591aa8ee16597370be861d0b89f8ec579db13fed58e708e1561d9b0f85f3cc3b"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -482,8 +502,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c667179a48c6076132fb617dc3d29246ead144ccd8a680337a986057ee4787"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -493,8 +514,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f98128293b2e228b895074be55665b5905d39cdb91d8d7e354bfe13c1e3d71a"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -508,8 +530,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core.git?branch=issue/237#80ed189b7050336a599a4dca8c6e79494f3638f0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597fdec667e61a83e572d77848bc9cf08c386a4bf34fcd70960a23f430872469"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",
@@ -956,6 +979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elain"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba39bdf557eef05f2c1c2e986cbab6b85329b922e7606e5b63ee4c5037ba77a"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1933,7 +1962,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2332,7 +2361,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2754,7 +2783,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
  "spideroak-base58",
  "spideroak-crypto",
  "thiserror 2.0.12",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1743,11 +1743,11 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2915,32 +2915,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,23 @@ tokio-util = { version = "0.7.12" }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
+[patch.crates-io]
+aranya-aqc-util = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-capi-codegen = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-capi-core = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-crypto = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-crypto-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-device-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-envelope-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-fast-channels = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-idam-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-perspective-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-policy-compiler = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-policy-ifgen = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-policy-ifgen-build = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-policy-lang = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-policy-vm = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
+aranya-runtime = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,22 +35,22 @@ unwrap_used = "warn"
 wildcard_imports = "warn"
 
 [workspace.dependencies]
-aranya-aqc-util = { version = "0.2.0", features = ["alloc"] }
-aranya-capi-core = { version = "0.3.0" }
-aranya-capi-codegen = { version = "0.2.3" }
-aranya-crypto = { version = "0.5.0", features = ["alloc", "fs-keystore", "clone-aead", "std"] }
-aranya-crypto-ffi = { version = "0.7.0" }
-aranya-device-ffi = { version = "0.7.0" }
-aranya-envelope-ffi = { version = "0.7.0" }
-aranya-fast-channels = { version = "0.6.0", features = ["posix", "std", "memory"] }
-aranya-idam-ffi = { version = "0.7.0" }
-aranya-perspective-ffi = { version = "0.7.0" }
-aranya-policy-compiler = { version = "0.7.0" }
-aranya-policy-ifgen = { version = "0.7.0", features = ["serde"] }
+aranya-aqc-util = { version = "0.3.0", features = ["alloc"] }
+aranya-capi-core = { version = "0.4.0" }
+aranya-capi-codegen = { version = "0.3.0" }
+aranya-crypto = { version = "0.6.0", features = ["alloc", "fs-keystore", "clone-aead", "std"] }
+aranya-crypto-ffi = { version = "0.8.0" }
+aranya-device-ffi = { version = "0.8.0" }
+aranya-envelope-ffi = { version = "0.8.0" }
+aranya-fast-channels = { version = "0.7.0", features = ["posix", "std", "memory"] }
+aranya-idam-ffi = { version = "0.8.0" }
+aranya-perspective-ffi = { version = "0.8.0" }
+aranya-policy-compiler = { version = "0.8.0" }
+aranya-policy-ifgen = { version = "0.8.0", features = ["serde"] }
 aranya-policy-ifgen-build = { version = "0.4.0" }
 aranya-policy-lang = { version = "0.4.0" }
-aranya-policy-vm = { version = "0.7.0", features = ["std"] }
-aranya-runtime = { version = "0.7.0", features = ["std", "libc"] }
+aranya-policy-vm = { version = "0.8.0", features = ["std"] }
+aranya-runtime = { version = "0.8.0", features = ["std", "libc"] }
 
 buggy = { version = "0.1.0" }
 
@@ -78,24 +78,6 @@ tokio = { version = "1.44" }
 tokio-util = { version = "0.7.12" }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-
-[patch.crates-io]
-aranya-aqc-util = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-capi-codegen = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-capi-core = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-crypto = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-crypto-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-device-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-envelope-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-fast-channels = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-idam-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-perspective-ffi = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-policy-compiler = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-policy-ifgen = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-policy-ifgen-build = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-policy-lang = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-policy-vm = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
-aranya-runtime = { git = "https://github.com/aranya-project/aranya-core.git", branch = "issue/237" }
 
 [profile.dev]
 opt-level = 1

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -88,7 +88,7 @@
 /**
  * The size in bytes of an ID
  */
-#define ARANYA_ID_LEN 64
+#define ARANYA_ID_LEN 32
 
 /**
  * The size in bytes of an ID converted to a human-readable base58 string.

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -1,6 +1,6 @@
 use core::{
     ffi::{c_char, CStr},
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
     ptr,
 };
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
@@ -203,7 +203,7 @@ pub unsafe fn client_init(
             .connect()
     })?;
 
-    Safe::init(client, imp::Client { rt, inner });
+    Client::init(client, imp::Client { rt, inner });
     Ok(())
 }
 
@@ -499,7 +499,7 @@ pub unsafe fn get_key_bundle(
     keybundle: *mut MaybeUninit<u8>,
     keybundle_len: &mut usize,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let keys = client.rt.block_on(client.inner.get_key_bundle())?;
     // SAFETY: Must trust caller provides valid ptr/len for keybundle buffer.
     unsafe { imp::key_bundle_serialize(&keys, keybundle, keybundle_len)? };
@@ -553,7 +553,7 @@ pub unsafe fn id_from_str(str: *const c_char) -> Result<Id, imp::Error> {
 ///
 /// @relates AranyaClient.
 pub fn get_device_id(client: &mut Client) -> Result<DeviceId, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let id = client.rt.block_on(client.inner.get_device_id())?;
     Ok(id.into())
 }
@@ -649,7 +649,7 @@ pub fn aqc_config_builder_set_address(cfg: &mut AqcConfigBuilder, address: *cons
 /// @param cfg a pointer to the client config builder
 /// @param aqc_config a pointer to a valid AQC config (see [`AqcConfigBuilder`])
 pub fn client_config_builder_set_aqc_config(cfg: &mut ClientConfigBuilder, aqc_config: &AqcConfig) {
-    cfg.aqc(aqc_config.deref().clone());
+    cfg.aqc((**aqc_config).clone());
 }
 
 #[aranya_capi_core::opaque(size = 24, align = 8)]
@@ -752,7 +752,7 @@ pub fn assign_role(
     device: &DeviceId,
     role: Role,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client.rt.block_on(
         client
             .inner
@@ -778,7 +778,7 @@ pub fn revoke_role(
     device: &DeviceId,
     role: Role,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client.rt.block_on(
         client
             .inner
@@ -802,7 +802,7 @@ pub fn create_label(
     team: &TeamId,
     name: LabelName,
 ) -> Result<LabelId, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `name` is a valid C String.
     let name = unsafe { name.as_underlying() }?;
     let label_id = client
@@ -825,7 +825,7 @@ pub fn delete_label(
     team: &TeamId,
     label_id: &LabelId,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client
         .rt
         .block_on(client.inner.team(team.into()).delete_label(label_id.into()))?;
@@ -849,7 +849,7 @@ pub fn assign_label(
     label_id: &LabelId,
     op: ChanOp,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client
         .rt
         .block_on(client.inner.team(team.into()).assign_label(
@@ -876,7 +876,7 @@ pub fn revoke_label(
     device: &DeviceId,
     label_id: &LabelId,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client.rt.block_on(
         client
             .inner
@@ -895,7 +895,7 @@ pub fn revoke_label(
 /// @relates AranyaClient.
 #[allow(unused_variables)] // TODO(nikki): once we have fields on TeamConfig, remove this for cfg
 pub fn create_team(client: &mut Client, cfg: &TeamConfig) -> Result<TeamId, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let cfg = aranya_client::TeamConfig::builder().build()?;
     let id = client.rt.block_on(client.inner.create_team(cfg))?;
     Ok(id.into())
@@ -912,7 +912,7 @@ pub fn create_team(client: &mut Client, cfg: &TeamConfig) -> Result<TeamId, imp:
 /// @relates AranyaClient.
 #[allow(unused_variables)] // TODO(nikki): once we have fields on TeamConfig, remove this for cfg
 pub fn add_team(client: &mut Client, team: &TeamId, cfg: &TeamConfig) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let cfg = aranya_client::TeamConfig::builder().build()?;
     client
         .rt
@@ -927,7 +927,7 @@ pub fn add_team(client: &mut Client, team: &TeamId, cfg: &TeamConfig) -> Result<
 ///
 /// @relates AranyaClient.
 pub fn remove_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client.rt.block_on(client.inner.remove_team(team.into()))?;
     Ok(())
 }
@@ -939,7 +939,7 @@ pub fn remove_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error>
 ///
 /// @relates AranyaClient.
 pub fn close_team(client: &mut Client, team: &TeamId) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client
         .rt
         .block_on(client.inner.team(team.into()).close_team())?;
@@ -961,7 +961,7 @@ pub unsafe fn add_device_to_team(
     team: &TeamId,
     keybundle: &[u8],
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let keybundle = imp::key_bundle_deserialize(keybundle)?;
 
     client
@@ -984,7 +984,7 @@ pub fn remove_device_from_team(
     team: &TeamId,
     device: &DeviceId,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client.rt.block_on(
         client
             .inner
@@ -1012,7 +1012,7 @@ pub unsafe fn add_sync_peer(
     addr: Addr,
     config: &SyncPeerConfig,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `addr` is a valid C String.
     let addr = unsafe { addr.as_underlying() }?;
     client.rt.block_on(
@@ -1036,7 +1036,7 @@ pub unsafe fn remove_sync_peer(
     team: &TeamId,
     addr: Addr,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `addr` is a valid C String.
     let addr = unsafe { addr.as_underlying() }?;
     client
@@ -1067,7 +1067,7 @@ pub unsafe fn sync_now(
     addr: Addr,
     config: Option<&SyncPeerConfig>,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `addr` is a valid C String.
     let addr = unsafe { addr.as_underlying() }?;
     client.rt.block_on(
@@ -1093,7 +1093,7 @@ pub fn query_devices_on_team(
     devices: Option<&mut MaybeUninit<DeviceId>>,
     devices_len: &mut usize,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let data = client
         .rt
         .block_on(client.inner.queries(team.into()).devices_on_team())?;
@@ -1132,7 +1132,7 @@ pub unsafe fn query_device_keybundle(
     keybundle: *mut MaybeUninit<u8>,
     keybundle_len: &mut usize,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let keys = client.rt.block_on(
         client
             .inner
@@ -1166,7 +1166,7 @@ pub fn query_device_label_assignments(
     labels: Option<&mut MaybeUninit<LabelId>>,
     labels_len: &mut usize,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let data = client.rt.block_on(
         client
             .inner
@@ -1210,7 +1210,7 @@ pub fn query_labels(
     labels: Option<&mut MaybeUninit<LabelId>>,
     labels_len: &mut usize,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let data = client
         .rt
         .block_on(client.inner.queries(team.into()).labels())?;
@@ -1245,7 +1245,7 @@ pub unsafe fn query_label_exists(
     team: &TeamId,
     label: &LabelId,
 ) -> Result<bool, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let exists = client
         .rt
         .block_on(client.inner.queries(team.into()).label_exists(label.into()))?;
@@ -1267,7 +1267,7 @@ pub unsafe fn query_aqc_net_identifier(
     ident: &mut MaybeUninit<c_char>,
     ident_len: &mut usize,
 ) -> Result<bool, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     let Some(net_identifier) = client.rt.block_on(
         client
             .inner
@@ -1302,7 +1302,7 @@ pub unsafe fn aqc_assign_net_identifier(
     device: &DeviceId,
     net_identifier: NetIdentifier,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `net_identifier` is a valid C String.
     let net_identifier = unsafe { net_identifier.as_underlying() }?;
     client.rt.block_on(
@@ -1330,7 +1330,7 @@ pub unsafe fn aqc_remove_net_identifier(
     device: &DeviceId,
     net_identifier: NetIdentifier,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `net_identifier` is a valid C String.
     let net_identifier = unsafe { net_identifier.as_underlying() }?;
     client.rt.block_on(
@@ -1362,7 +1362,7 @@ pub unsafe fn aqc_create_bidi_channel(
     peer: NetIdentifier,
     label_id: &LabelId,
 ) -> Result<AqcBidiChannelId, imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     // SAFETY: Caller must ensure `peer` is a valid C String.
     let peer = unsafe { peer.as_underlying() }?;
     let chan_id = client.rt.block_on(client.inner.aqc().create_bidi_channel(
@@ -1383,7 +1383,7 @@ pub fn aqc_delete_bidi_channel(
     client: &mut Client,
     chan: &AqcBidiChannelId,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client
         .rt
         .block_on(client.inner.aqc().delete_bidi_channel(chan.into()))?;
@@ -1400,7 +1400,7 @@ pub fn aqc_delete_uni_channel(
     client: &mut Client,
     chan: &AqcUniChannelId,
 ) -> Result<(), imp::Error> {
-    let client = client.deref_mut();
+    let client = client.imp();
     client
         .rt
         .block_on(client.inner.aqc().delete_uni_channel(chan.into()))?;

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -213,7 +213,7 @@ pub unsafe fn client_init(
 pub type Client = Safe<imp::Client>;
 
 /// The size in bytes of an ID
-pub const ARANYA_ID_LEN: usize = 64;
+pub const ARANYA_ID_LEN: usize = 32;
 
 const _: () = {
     assert!(ARANYA_ID_LEN == size_of::<aranya_crypto::Id>());

--- a/crates/aranya-client-capi/src/imp/client.rs
+++ b/crates/aranya-client-capi/src/imp/client.rs
@@ -7,6 +7,13 @@ pub struct Client {
     pub(crate) rt: tokio::runtime::Runtime,
 }
 
+impl Client {
+    /// Useful for deref coercion.
+    pub(crate) fn imp(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl Typed for Client {
     const TYPE_ID: TypeId = TypeId::new(0xbbafb41c);
 }

--- a/crates/aranya-client-capi/src/imp/config.rs
+++ b/crates/aranya-client-capi/src/imp/config.rs
@@ -1,12 +1,12 @@
 use core::{ffi::c_char, mem::MaybeUninit, ptr};
 
 use aranya_capi_core::{
-    safe::{Safe, TypeId, Typed},
+    safe::{TypeId, Typed},
     Builder, InvalidArg,
 };
 
 use super::Error;
-use crate::api::defs::Duration;
+use crate::api::defs::{self, Duration};
 
 /// Configuration info for Aranya
 #[derive(Clone, Debug)]
@@ -61,7 +61,7 @@ impl Typed for ClientConfigBuilder {
 }
 
 impl Builder for ClientConfigBuilder {
-    type Output = Safe<ClientConfig>;
+    type Output = defs::ClientConfig;
     type Error = Error;
 
     /// # Safety
@@ -85,7 +85,7 @@ impl Builder for ClientConfigBuilder {
             pk: pk.clone(),
             _aqc: aqc,
         };
-        Safe::init(out, cfg);
+        Self::Output::init(out, cfg);
         Ok(())
     }
 }
@@ -127,7 +127,7 @@ impl AqcConfigBuilder {
 }
 
 impl Builder for AqcConfigBuilder {
-    type Output = Safe<AqcConfig>;
+    type Output = defs::AqcConfig;
     type Error = Error;
 
     /// # Safety
@@ -140,7 +140,7 @@ impl Builder for AqcConfigBuilder {
 
         let cfg = AqcConfig { _addr: self.addr };
 
-        Safe::init(out, cfg);
+        Self::Output::init(out, cfg);
         Ok(())
     }
 }
@@ -204,7 +204,7 @@ impl SyncPeerConfigBuilder {
 }
 
 impl Builder for SyncPeerConfigBuilder {
-    type Output = Safe<SyncPeerConfig>;
+    type Output = defs::SyncPeerConfig;
     type Error = Error;
 
     /// # Safety
@@ -219,7 +219,7 @@ impl Builder for SyncPeerConfigBuilder {
             interval,
             sync_now: self.sync_now,
         };
-        Safe::init(out, cfg);
+        Self::Output::init(out, cfg);
         Ok(())
     }
 }
@@ -254,14 +254,14 @@ impl Typed for TeamConfigBuilder {
 }
 
 impl Builder for TeamConfigBuilder {
-    type Output = Safe<TeamConfig>;
+    type Output = defs::TeamConfig;
     type Error = Error;
 
     /// # Safety
     ///
     /// No special considerations.
     unsafe fn build(self, out: &mut MaybeUninit<Self::Output>) -> Result<(), Self::Error> {
-        Safe::init(out, TeamConfig {});
+        Self::Output::init(out, TeamConfig {});
         Ok(())
     }
 }

--- a/crates/aranya-client/src/aqc.rs
+++ b/crates/aranya-client/src/aqc.rs
@@ -63,21 +63,21 @@ impl<'a> AqcChannels<'a> {
     ) -> Result<AqcBidiChannelId> {
         debug!("creating bidi channel");
 
-        let (ctrl, psk) = self
+        let (ctrl, psks) = self
             .client
             .daemon
             .create_aqc_bidi_channel(context::current(), team_id, peer.clone(), label_id)
             .await
             .map_err(IpcError::new)?
             .map_err(aranya_error)?;
-        debug!(%label_id, psk_ident = ?psk.identity, "created bidi channel");
+        debug!(%label_id, num_psks = psks.len(), "created bidi channel");
 
-        let chan_id = psk.identity.into();
+        let chan_id = *psks[0].identity.channel_id();
 
         // TODO: send ctrl msg via network.
         let _ = ctrl;
 
-        Ok(chan_id)
+        Ok(chan_id.into_id().into())
     }
 
     /// Creates a unidirectional AQC channel with a peer.
@@ -97,21 +97,21 @@ impl<'a> AqcChannels<'a> {
     ) -> Result<AqcUniChannelId> {
         debug!("creating aqc uni channel");
 
-        let (ctrl, psk) = self
+        let (ctrl, psks) = self
             .client
             .daemon
             .create_aqc_uni_channel(context::current(), team_id, peer.clone(), label_id)
             .await
             .map_err(IpcError::new)?
             .map_err(aranya_error)?;
-        debug!(%label_id, psk_ident = ?psk.identity, "created bidi channel");
+        debug!(%label_id, num_psks = psks.len(), "created bidi channel");
 
-        let chan_id = psk.identity.into();
+        let chan_id = *psks[0].identity.channel_id();
 
         // TODO: send ctrl msg via network.
         let _ = ctrl;
 
-        Ok(chan_id)
+        Ok(chan_id.into_id().into())
     }
 
     /// Deletes an AQC bidi channel.
@@ -149,7 +149,7 @@ impl<'a> AqcChannels<'a> {
     // In final AQC implementation, it will only be invoked when a ctrl msg is received via the network.
     #[instrument(skip_all, fields(%team))]
     async fn receive_aqc_ctrl(&mut self, team: TeamId, ctrl: AqcCtrl) -> Result<()> {
-        let (_net_id, psk) = self
+        let (_net_id, psks) = self
             .client
             .daemon
             .receive_aqc_ctrl(context::current(), team, ctrl)
@@ -157,12 +157,14 @@ impl<'a> AqcChannels<'a> {
             .map_err(IpcError::new)?
             .map_err(aranya_error)?;
 
-        match psk {
-            AqcPsk::Bidi(psk) => {
-                debug!(identity = ?psk.identity, "bidi psk identity");
-            }
-            AqcPsk::Uni(psk) => {
-                debug!(identity = ?psk.identity, "uni psk identity");
+        for psk in psks {
+            match psk {
+                AqcPsk::Bidi(psk) => {
+                    debug!(identity = ?psk.identity, "bidi psk identity");
+                }
+                AqcPsk::Uni(psk) => {
+                    debug!(identity = ?psk.identity, "uni psk identity");
+                }
             }
         }
 

--- a/crates/aranya-client/src/aqc.rs
+++ b/crates/aranya-client/src/aqc.rs
@@ -3,7 +3,7 @@
 use core::{fmt, net::SocketAddr};
 
 pub use aranya_daemon_api::{AqcBidiChannelId, AqcUniChannelId};
-use aranya_daemon_api::{AqcCtrl, AqcPsk, LabelId, NetIdentifier, TeamId};
+use aranya_daemon_api::{AqcCtrl, AqcPsks, LabelId, NetIdentifier, TeamId};
 use tarpc::context;
 use tracing::{debug, instrument};
 
@@ -72,12 +72,12 @@ impl<'a> AqcChannels<'a> {
             .map_err(aranya_error)?;
         debug!(%label_id, num_psks = psks.len(), "created bidi channel");
 
-        let chan_id = *psks[0].identity.channel_id();
+        let chan_id = *psks.channel_id();
 
         // TODO: send ctrl msg via network.
         let _ = ctrl;
 
-        Ok(chan_id.into_id().into())
+        Ok(chan_id.into())
     }
 
     /// Creates a unidirectional AQC channel with a peer.
@@ -106,12 +106,12 @@ impl<'a> AqcChannels<'a> {
             .map_err(aranya_error)?;
         debug!(%label_id, num_psks = psks.len(), "created bidi channel");
 
-        let chan_id = *psks[0].identity.channel_id();
+        let chan_id = *psks.channel_id();
 
         // TODO: send ctrl msg via network.
         let _ = ctrl;
 
-        Ok(chan_id.into_id().into())
+        Ok(chan_id.into())
     }
 
     /// Deletes an AQC bidi channel.
@@ -157,13 +157,15 @@ impl<'a> AqcChannels<'a> {
             .map_err(IpcError::new)?
             .map_err(aranya_error)?;
 
-        for psk in psks {
-            match psk {
-                AqcPsk::Bidi(psk) => {
-                    debug!(identity = ?psk.identity, "bidi psk identity");
+        match psks {
+            AqcPsks::Bidi(psks) => {
+                for (suite, psk) in psks {
+                    debug!(identity = ?psk.identity, %suite, "bidi psk");
                 }
-                AqcPsk::Uni(psk) => {
-                    debug!(identity = ?psk.identity, "uni psk identity");
+            }
+            AqcPsks::Uni(psks) => {
+                for (suite, psk) in psks {
+                    debug!(identity = ?psk.identity, %suite, "uni psk");
                 }
             }
         }

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -491,7 +491,7 @@ impl DaemonApi for Api {
         team: api::TeamId,
         peer: api::NetIdentifier,
         label: api::LabelId,
-    ) -> api::Result<(api::AqcCtrl, Box<[api::AqcBidiPsk]>)> {
+    ) -> api::Result<(api::AqcCtrl, api::AqcBidiPsks)> {
         info!("creating bidi channel");
 
         let graph = GraphId::from(team.into_id());
@@ -530,7 +530,7 @@ impl DaemonApi for Api {
         team: api::TeamId,
         peer: api::NetIdentifier,
         label: api::LabelId,
-    ) -> api::Result<(api::AqcCtrl, Box<[api::AqcUniPsk]>)> {
+    ) -> api::Result<(api::AqcCtrl, api::AqcUniPsks)> {
         info!("creating uni channel");
 
         let graph = GraphId::from(team.into_id());
@@ -588,7 +588,7 @@ impl DaemonApi for Api {
         _: context::Context,
         team: api::TeamId,
         ctrl: api::AqcCtrl,
-    ) -> api::Result<(api::NetIdentifier, Box<[api::AqcPsk]>)> {
+    ) -> api::Result<(api::NetIdentifier, api::AqcPsks)> {
         let graph = GraphId::from(team.into_id());
         let mut session = self.client.session_new(&graph).await?;
         for cmd in ctrl {

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -491,7 +491,7 @@ impl DaemonApi for Api {
         team: api::TeamId,
         peer: api::NetIdentifier,
         label: api::LabelId,
-    ) -> api::Result<(api::AqcCtrl, api::AqcBidiPsk)> {
+    ) -> api::Result<(api::AqcCtrl, Box<[api::AqcBidiPsk]>)> {
         info!("creating bidi channel");
 
         let graph = GraphId::from(team.into_id());
@@ -512,15 +512,15 @@ impl DaemonApi for Api {
         let Some(Effect::AqcBidiChannelCreated(e)) =
             find_effect!(&effects, Effect::AqcBidiChannelCreated(e) if e.author_id == id.into())
         else {
-            return Err(anyhow!("unable to find AqcBidiChannelCreated effect").into());
+            return Err(anyhow!("unable to find `AqcBidiChannelCreated` effect").into());
         };
 
         self.handler.handle_effects(graph, &effects).await?;
 
-        let psk = self.aqc.bidi_channel_created(e).await?;
-        info!(identity = %psk.identity, "psk identity");
+        let psks = self.aqc.bidi_channel_created(e).await?;
+        info!(num = psks.len(), "bidi channel created");
 
-        Ok((ctrl, psk))
+        Ok((ctrl, psks))
     }
 
     #[instrument(skip(self))]
@@ -530,7 +530,7 @@ impl DaemonApi for Api {
         team: api::TeamId,
         peer: api::NetIdentifier,
         label: api::LabelId,
-    ) -> api::Result<(api::AqcCtrl, api::AqcUniPsk)> {
+    ) -> api::Result<(api::AqcCtrl, Box<[api::AqcUniPsk]>)> {
         info!("creating uni channel");
 
         let graph = GraphId::from(team.into_id());
@@ -556,10 +556,10 @@ impl DaemonApi for Api {
 
         self.handler.handle_effects(graph, &effects).await?;
 
-        let psk = self.aqc.uni_channel_created(e).await?;
-        info!(identity = %psk.identity, "psk identity");
+        let psks = self.aqc.uni_channel_created(e).await?;
+        info!(num = psks.len(), "bidi channel created");
 
-        Ok((ctrl, psk))
+        Ok((ctrl, psks))
     }
 
     #[instrument(skip(self))]
@@ -588,7 +588,7 @@ impl DaemonApi for Api {
         _: context::Context,
         team: api::TeamId,
         ctrl: api::AqcCtrl,
-    ) -> api::Result<(api::NetIdentifier, api::AqcPsk)> {
+    ) -> api::Result<(api::NetIdentifier, Box<[api::AqcPsk]>)> {
         let graph = GraphId::from(team.into_id());
         let mut session = self.client.session_new(&graph).await?;
         for cmd in ctrl {
@@ -606,7 +606,7 @@ impl DaemonApi for Api {
             });
             match effect {
                 Some(Effect::AqcBidiChannelReceived(e)) => {
-                    let psk = self.aqc.bidi_channel_received(e).await?;
+                    let psks = self.aqc.bidi_channel_received(e).await?;
                     let net_id = self
                         .aqc
                         .find_net_id(graph, e.author_id.into())
@@ -614,10 +614,10 @@ impl DaemonApi for Api {
                         .context("missing net identifier for channel author")?;
                     // NB: Each action should only produce one
                     // ephemeral command.
-                    return Ok((net_id, api::AqcPsk::Bidi(psk)));
+                    return Ok((net_id, psks));
                 }
                 Some(Effect::AqcUniChannelReceived(e)) => {
-                    let psk = self.aqc.uni_channel_received(e).await?;
+                    let psks = self.aqc.uni_channel_received(e).await?;
                     let net_id = self
                         .aqc
                         .find_net_id(graph, e.author_id.into())
@@ -625,7 +625,7 @@ impl DaemonApi for Api {
                         .context("missing net identifier for channel author")?;
                     // NB: Each action should only produce one
                     // ephemeral command.
-                    return Ok((net_id, api::AqcPsk::Uni(psk)));
+                    return Ok((net_id, psks));
                 }
                 Some(_) | None => {}
             }

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e19bd18f91c86681abafb6fd4d33e13ab1462732506f3f8572b6c829ddc604f"
+checksum = "9ef7649eb26ccaac46800248d215e374f752083723754e5f24e261a7bdc2dd34"
 dependencies = [
  "buggy",
  "byteorder",
@@ -101,6 +101,7 @@ dependencies = [
  "spideroak-base58",
  "spideroak-crypto",
  "thiserror 2.0.12",
+ "zerocopy",
 ]
 
 [[package]]
@@ -141,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeb9a850d354b99fa5c460119dfd1f6430ce20d9f11eb215b78d8283f117af6"
+checksum = "92381ca0694401c40f95d0441be52e70100dd1c1c30b444c87829b7093281de2"
 dependencies = [
  "aranya-crypto",
  "buggy",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -136,6 +136,11 @@ who = "gknopf <gknopf@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.15 -> 0.2.16"
 
+[[audits.ppv-lite86]]
+who = "Eric Lagergren <elagergren@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.20 -> 0.2.21"
+
 [[audits.prettyplease]]
 who = "gknopf <gknopf@spideroak.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -7,6 +7,9 @@ version = "0.10"
 [imports.actix]
 url = "https://raw.githubusercontent.com/actix/supply-chain/main/audits.toml"
 
+[imports.aranya-core]
+url = "https://raw.githubusercontent.com/aranya-project/aranya-core/refs/heads/main/supply-chain/audits.toml"
+
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,62 +2,62 @@
 # cargo-vet imports lock
 
 [[publisher.aranya-aqc-util]]
-version = "0.2.0"
-when = "2025-04-21"
+version = "0.3.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-capi-codegen]]
-version = "0.2.3"
-when = "2025-04-08"
+version = "0.3.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-capi-core]]
-version = "0.3.0"
-when = "2025-04-21"
+version = "0.4.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-capi-macro]]
-version = "0.2.2"
-when = "2025-04-08"
+version = "0.3.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-crypto]]
-version = "0.5.0"
-when = "2025-04-10"
+version = "0.6.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-crypto-ffi]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-device-ffi]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-envelope-ffi]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-fast-channels]]
-version = "0.6.0"
-when = "2025-04-10"
+version = "0.7.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-idam-ffi]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -68,38 +68,38 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-perspective-ffi]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-ast]]
-version = "0.4.0"
-when = "2025-04-21"
+version = "0.4.1"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-compiler]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-derive]]
-version = "0.5.0"
-when = "2025-04-21"
+version = "0.5.1"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-ifgen]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-ifgen-build]]
-version = "0.4.0"
-when = "2025-04-21"
+version = "0.4.1"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -110,26 +110,26 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-lang]]
-version = "0.4.0"
-when = "2025-04-21"
+version = "0.4.1"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-module]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-vm]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-runtime]]
-version = "0.7.0"
-when = "2025-04-21"
+version = "0.8.0"
+when = "2025-05-19"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -154,6 +154,21 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [audits.actix.audits]
+
+[[audits.aranya-core.audits.elain]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
+[[audits.aranya-core.audits.zerocopy]]
+who = "Eric Lagergren <elagergren@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.35 -> 0.8.25"
+
+[[audits.aranya-core.audits.zerocopy-derive]]
+who = "Eric Lagergren <elagergren@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.35 -> 0.8.25"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"


### PR DESCRIPTION
This implementation assumes that the client only supports the cipher suites listed in [RFC 8446]. This is a fine assumption for now, but we might need to change it in the future if we allow users to customize the TLS implementation.

To change this, the caller could supply the list of supported cipher suites. Or the daemon could send the `BidiSecret`/`UniSecret` to the client, but that's trickier since `BidiSecret` and `UniSecret` are currently wrappers around the HPKE context, which can't reasonably be `Serialize`/`Deserialize`.

Fixes #259

[RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4