### PR TITLE
release: 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-aqc-util",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-keygen"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-util"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-fast-channels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 authors = ["SpiderOak, Inc."]
 edition = "2021"
 license = "AGPL-3.0-only"
@@ -53,11 +53,11 @@ aranya-runtime = { version = "0.8.0", features = ["std", "libc"] }
 
 buggy = { version = "0.1.0" }
 
-aranya-client = { version = "0.5.1", path = "crates/aranya-client" }
-aranya-daemon = { version = "0.5.1", path = "crates/aranya-daemon" }
-aranya-daemon-api = { version = "0.5.1", path = "crates/aranya-daemon-api" }
-aranya-keygen = { version = "0.5.1", path = "crates/aranya-keygen" }
-aranya-util = { version = "0.5.1", path = "crates/aranya-util" }
+aranya-client = { version = "0.6.0", path = "crates/aranya-client" }
+aranya-daemon = { version = "0.6.0", path = "crates/aranya-daemon" }
+aranya-daemon-api = { version = "0.6.0", path = "crates/aranya-daemon-api" }
+aranya-keygen = { version = "0.6.0", path = "crates/aranya-keygen" }
+aranya-util = { version = "0.6.0", path = "crates/aranya-util" }
 
 anyhow = { version = "1.0.86" }
 bytes = { version = "1.0" }

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "aranya-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-util"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-fast-channels",


### PR DESCRIPTION
Bump aranya crate versions for release 0.6.0.
This release includes the new AQC feature.

The following PRs should be merged before this one:
- [x] https://github.com/aranya-project/aranya/pull/245