### PR TITLE
aqc: update rust example readme

### DIFF
--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -3,10 +3,10 @@
 This crate contains example code showing how to use Aranya in a Rust application.
 
 This example shows how to use the [`aranya-client`](../../crates/aranya-client) library to:
-- [Setup a team](https://aranya-project.github.io/aranya-docs/getting-started/walkthrough/#create-team)
-- [Sync Aranya graphs](https://aranya-project.github.io/aranya-docs/getting-started/walkthrough/#syncer)
-- [Create an Aranya Fast Channel](https://aranya-project.github.io/aranya-docs/getting-started/walkthrough/#off-graph-messaging)
-- [Send encrypted data between peers](https://aranya-project.github.io/aranya-docs/getting-started/walkthrough/#send-messages)
+- Setup a team
+- Sync Aranya graphs
+- Create an AQC (Aranya QUIC) channel
+- Send encrypted data between peers
 
 During setup, the example application starts an instance of the [`aranya-daemon`](../../crates/aranya-daemon) for each Aranya device in the background. [The daemon](https://aranya-project.github.io/aranya-docs/technical-apis/rust-api/#aranya-daemon) handles low-level operations such as automatically syncing graph states between different devices so that [the client](https://aranya-project.github.io/aranya-docs/technical-apis/rust-api/#aranya-client) can focus on the operations it wants to perform on the team.
 


### PR DESCRIPTION
Rust example README is out-of-date after the AQC release.
This PR gets the README up-to-date and makes it less likely to become out of date in the future by removing implementation specific references/links from the README.