### PR TITLE
Fix ctrl recv error causing flake

### DIFF
--- a/crates/aranya-client/src/aqc/net.rs
+++ b/crates/aranya-client/src/aqc/net.rs
@@ -14,7 +14,7 @@ use aranya_daemon_api::{
     AqcBidiPsks, AqcCtrl, AqcPsks, AqcUniPsks, DaemonApiClient, LabelId, TeamId,
 };
 use buggy::{Bug, BugExt as _};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use channels::AqcPeerChannel;
 use s2n_quic::{
     self,
@@ -26,6 +26,7 @@ use s2n_quic::{
             rustls::{server::PresharedKeySelection, ClientConfig, ServerConfig},
         },
     },
+    stream::BidirectionalStream,
     Client, Connection, Server,
 };
 use tarpc::context;
@@ -304,18 +305,20 @@ impl AqcClient {
             .quic_client
             .connect(Connect::new(addr).with_server_name(addr.ip().to_string()))
             .await?;
-        conn.keep_alive(true)?;
         let mut stream = conn.open_bidirectional_stream().await?;
+
         let msg = AqcCtrlMessage { team_id, ctrl };
         let msg_bytes = postcard::to_stdvec(&msg).assume("can serialize")?;
-        stream.send(Bytes::from_owner(msg_bytes)).await?;
-        if let Some(msg_bytes) = stream.receive().await? {
-            let msg = postcard::from_bytes::<AqcAckMessage>(&msg_bytes).map_err(AqcError::Serde)?;
-            match msg {
-                AqcAckMessage::Success => (),
-                AqcAckMessage::Failure(e) => return Err(AqcError::CtrlFailure(e)),
-            }
+        stream.send(Bytes::from(msg_bytes)).await?;
+        stream.finish()?;
+
+        let ack_bytes = read_to_end(&mut stream).await?;
+        let ack = postcard::from_bytes::<AqcAckMessage>(&ack_bytes).map_err(AqcError::Serde)?;
+        match ack {
+            AqcAckMessage::Success => (),
+            AqcAckMessage::Failure(e) => return Err(AqcError::CtrlFailure(e)),
         }
+
         Ok(())
     }
 
@@ -325,10 +328,7 @@ impl AqcClient {
             .await
             .map_err(AqcError::ConnectionError)?
             .ok_or(AqcError::ConnectionClosed)?;
-        let Ok(Some(ctrl_bytes)) = stream.receive().await else {
-            error!("Failed to receive control message or stream closed");
-            return Err(AqcError::ConnectionClosed.into());
-        };
+        let ctrl_bytes = read_to_end(&mut stream).await.map_err(AqcError::from)?;
         match postcard::from_bytes::<AqcCtrlMessage>(&ctrl_bytes) {
             Ok(ctrl) => {
                 self.process_ctrl_message(ctrl.team_id, ctrl.ctrl).await?;
@@ -339,15 +339,18 @@ impl AqcClient {
                     .send(Bytes::from(ack_bytes))
                     .await
                     .map_err(AqcError::from)?;
-                stream.close().await.map_err(AqcError::from)?;
+                if let Err(err) = stream.close().await {
+                    if !is_close_error(err) {
+                        return Err(AqcError::from(err).into());
+                    }
+                }
             }
             Err(e) => {
                 error!("Failed to deserialize AqcCtrlMessage: {}", e);
                 let ack_msg =
                     AqcAckMessage::Failure(format!("Failed to deserialize AqcCtrlMessage: {e}"));
                 let ack_bytes = postcard::to_stdvec(&ack_msg).assume("can serialize")?;
-                let _ = stream.send(Bytes::from(ack_bytes)).await;
-                let _ = stream.close().await;
+                stream.send(Bytes::from(ack_bytes)).await.ok();
                 return Err(AqcError::Serde(e).into());
             }
         }
@@ -437,4 +440,33 @@ enum AqcAckMessage {
     Success,
     /// The failure message.
     Failure(String),
+}
+
+async fn read_to_end(stream: &mut BidirectionalStream) -> Result<Bytes, s2n_quic::stream::Error> {
+    let Some(first) = stream.receive().await? else {
+        return Ok(Bytes::new());
+    };
+    let Some(mut more) = stream.receive().await? else {
+        return Ok(first);
+    };
+    let mut buf = BytesMut::from(first);
+    loop {
+        buf.extend_from_slice(&more);
+        if let Some(even_more) = stream.receive().await? {
+            more = even_more;
+        } else {
+            break;
+        }
+    }
+    Ok(buf.freeze())
+}
+
+fn is_close_error(err: s2n_quic::stream::Error) -> bool {
+    matches!(
+        err,
+        s2n_quic::stream::Error::ConnectionError {
+            error: s2n_quic::connection::Error::Closed { .. },
+            ..
+        },
+    )
 }


### PR DESCRIPTION
Read to the end of the stream and ignore close error when acking.

Kind of silly to me what make this fail AFAICT.
- Peer is reading all data until stream is finished
- We close the stream, which marks it as finished and "flushes" to wait for ack of all data
- The peer finishes reading all the data and closes the stream
- Our flushing fails because the stream is closed, even though the peer couldn't have closed it until after we called close
- This really feels like bad behavior to me.