### PR TITLE
capi: better cfg init docs

### DIFF
--- a/crates/aranya-client-capi/docs/static/mainpage.md
+++ b/crates/aranya-client-capi/docs/static/mainpage.md
@@ -32,6 +32,10 @@ Objects for creating an Aranya client and Aranya team:
 - `AranyaClientConfig`
 - `AranyaTeamConfig`
 - `AranyaTeamConfigBuilder`
+- `AranyaQuicSyncConfig`
+- `AranyaQuicSyncConfigBuilder`
+- `AranyaSyncPeerConfig`
+- `AranyaSyncPeerConfigBuilder`
 
 Objects for creating AQC (Aranya QUIC) channels and sending/receiving data:
 - `AranyaAqcConfig`

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -273,6 +273,7 @@ typedef struct ARANYA_ALIGNED(16) AranyaClient {
 
 /**
  * Configuration info for Aranya.
+ *
  * Use a [`AranyaClientConfigBuilder`](@ref AranyaClientConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaClientConfig {
@@ -324,6 +325,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaAqcConfigBuilder {
 
 /**
  * Configuration info for Aranya QUIC Channels.
+ *
  * Use a [`AranyaAqcConfigBuilder`](@ref AranyaAqcConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaAqcConfig {
@@ -337,6 +339,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaAqcConfig {
 
 /**
  * A builder for initializing a [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig).
+ *
  * The [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig) is an optional part of initializing a [`AranyaTeamConfig`](@ref AranyaTeamConfig).
  */
 typedef struct ARANYA_ALIGNED(8) AranyaQuicSyncConfigBuilder {
@@ -357,6 +360,7 @@ typedef struct AranyaSeedIkm {
 
 /**
  * QUIC syncer configuration.
+ *
  * Use a [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaQuicSyncConfig {
@@ -382,6 +386,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaTeamConfigBuilder {
 
 /**
  * Team configuration.
+ *
  * Use a [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaTeamConfig {
@@ -407,6 +412,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfigBuilder {
 
 /**
  * Sync Peer config.
+ *
  * Use a [`AranyaSyncPeerConfigBuilder`](@ref AranyaSyncPeerConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfig {
@@ -785,7 +791,6 @@ AranyaError aranya_id_to_str(const struct AranyaId *id,
 
 /**
  * Decodes `str` into an [`AranyaId`](@ref AranyaId).
- *
  *
  * @param str pointer to a null-terminated string.
  *
@@ -1652,6 +1657,7 @@ AranyaError aranya_create_team_ext(struct AranyaClient *client,
 
 /**
  * Return random bytes from Aranya's CSPRNG.
+ *
  * This method can be used to generate a PSK seed IKM for the QUIC syncer.
  *
  * @param[in] client the Aranya Client [`AranyaClient`](@ref AranyaClient).
@@ -1664,6 +1670,7 @@ AranyaError aranya_rand(struct AranyaClient *client,
 
 /**
  * Return random bytes from Aranya's CSPRNG.
+ *
  * This method can be used to generate a PSK seed IKM for the QUIC syncer.
  *
  * @param[in] client the Aranya Client [`AranyaClient`](@ref AranyaClient).
@@ -1677,6 +1684,7 @@ AranyaError aranya_rand_ext(struct AranyaClient *client,
 
 /**
  * Return serialized PSK seed encrypted for another device on the team.
+ *
  * The PSK seed will be encrypted using the public encryption key of the specified device on the team.
  *
  * Returns an `AranyaBufferTooSmall` error if the output buffer is too small to hold the seed bytes.
@@ -1700,6 +1708,7 @@ AranyaError aranya_encrypt_psk_seed_for_peer(struct AranyaClient *client,
 
 /**
  * Return serialized PSK seed encrypted for another device on the team.
+ *
  * The PSK seed will be encrypted using the public encryption key of the specified device on the team.
  *
  * Returns an `AranyaBufferTooSmall` error if the output buffer is too small to hold the seed bytes.

--- a/crates/aranya-client-capi/output/aranya-client.h
+++ b/crates/aranya-client-capi/output/aranya-client.h
@@ -273,6 +273,7 @@ typedef struct ARANYA_ALIGNED(16) AranyaClient {
 
 /**
  * Configuration info for Aranya.
+ * Use a [`AranyaClientConfigBuilder`](@ref AranyaClientConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaClientConfig {
     /**
@@ -283,6 +284,9 @@ typedef struct ARANYA_ALIGNED(8) AranyaClientConfig {
     uint8_t __for_size_only[56];
 } AranyaClientConfig;
 
+/**
+ * Cryptographically secure Aranya ID.
+ */
 typedef struct AranyaId {
     uint8_t bytes[ARANYA_ID_LEN];
 } AranyaId;
@@ -295,7 +299,7 @@ typedef struct AranyaDeviceId {
 } AranyaDeviceId;
 
 /**
- * Configuration info builder for Aranya.
+ * Configuration info builder for an Aranya client config [`AranyaClientConfig`](@ref AranyaClientConfig).
  */
 typedef struct ARANYA_ALIGNED(8) AranyaClientConfigBuilder {
     /**
@@ -307,7 +311,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaClientConfigBuilder {
 } AranyaClientConfigBuilder;
 
 /**
- * Configuration info builder for Aranya QUIC Channels.
+ * Configuration info builder for Aranya QUIC Channels config [`AranyaAqcConfig`](@ref AranyaAqcConfig).
  */
 typedef struct ARANYA_ALIGNED(8) AranyaAqcConfigBuilder {
     /**
@@ -320,6 +324,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaAqcConfigBuilder {
 
 /**
  * Configuration info for Aranya QUIC Channels.
+ * Use a [`AranyaAqcConfigBuilder`](@ref AranyaAqcConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaAqcConfig {
     /**
@@ -330,6 +335,10 @@ typedef struct ARANYA_ALIGNED(8) AranyaAqcConfig {
     uint8_t __for_size_only[40];
 } AranyaAqcConfig;
 
+/**
+ * A builder for initializing a [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig).
+ * The [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig) is an optional part of initializing a [`AranyaTeamConfig`](@ref AranyaTeamConfig).
+ */
 typedef struct ARANYA_ALIGNED(8) AranyaQuicSyncConfigBuilder {
     /**
      * This field only exists for size purposes. It is
@@ -346,6 +355,10 @@ typedef struct AranyaSeedIkm {
     uint8_t bytes[ARANYA_SEED_IKM_LEN];
 } AranyaSeedIkm;
 
+/**
+ * QUIC syncer configuration.
+ * Use a [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder) to construct this object.
+ */
 typedef struct ARANYA_ALIGNED(8) AranyaQuicSyncConfig {
     /**
      * This field only exists for size purposes. It is
@@ -355,6 +368,9 @@ typedef struct ARANYA_ALIGNED(8) AranyaQuicSyncConfig {
     uint8_t __for_size_only[288];
 } AranyaQuicSyncConfig;
 
+/**
+ * A builder for initializing a [`AranyaTeamConfig`](@ref AranyaTeamConfig).
+ */
 typedef struct ARANYA_ALIGNED(8) AranyaTeamConfigBuilder {
     /**
      * This field only exists for size purposes. It is
@@ -364,6 +380,10 @@ typedef struct ARANYA_ALIGNED(8) AranyaTeamConfigBuilder {
     uint8_t __for_size_only[288];
 } AranyaTeamConfigBuilder;
 
+/**
+ * Team configuration.
+ * Use a [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder) to construct this object.
+ */
 typedef struct ARANYA_ALIGNED(8) AranyaTeamConfig {
     /**
      * This field only exists for size purposes. It is
@@ -374,7 +394,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaTeamConfig {
 } AranyaTeamConfig;
 
 /**
- * Builder for a Sync Peer config.
+ * Builder for a Sync Peer config [`AranyaSyncPeerConfig`](@ref AranyaSyncPeerConfig).
  */
 typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfigBuilder {
     /**
@@ -387,6 +407,7 @@ typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfigBuilder {
 
 /**
  * Sync Peer config.
+ * Use a [`AranyaSyncPeerConfigBuilder`](@ref AranyaSyncPeerConfigBuilder) to construct this object.
  */
 typedef struct ARANYA_ALIGNED(8) AranyaSyncPeerConfig {
     /**
@@ -843,6 +864,8 @@ AranyaError aranya_client_config_builder_cleanup_ext(struct AranyaClientConfigBu
  *
  * @param cfg a pointer to the client config builder
  * @param out a pointer to write the client config to
+ *
+ * @relates AranyaClientConfigBuilder.
  */
 AranyaError aranya_client_config_build(struct AranyaClientConfigBuilder *cfg,
                                        struct AranyaClientConfig *out);
@@ -855,6 +878,8 @@ AranyaError aranya_client_config_build(struct AranyaClientConfigBuilder *cfg,
  *
  * @param cfg a pointer to the client config builder
  * @param out a pointer to write the client config to
+ *
+ * @relates AranyaClientConfigBuilder.
  */
 AranyaError aranya_client_config_build_ext(struct AranyaClientConfigBuilder *cfg,
                                            struct AranyaClientConfig *out,
@@ -865,6 +890,8 @@ AranyaError aranya_client_config_build_ext(struct AranyaClientConfigBuilder *cfg
  *
  * @param cfg a pointer to the client config builder
  * @param address a string containing the address
+ *
+ * @relates AranyaClientConfigBuilder.
  */
 AranyaError aranya_client_config_builder_set_daemon_uds_path(struct AranyaClientConfigBuilder *cfg,
                                                              const char *address);
@@ -874,6 +901,8 @@ AranyaError aranya_client_config_builder_set_daemon_uds_path(struct AranyaClient
  *
  * @param cfg a pointer to the client config builder
  * @param address a string containing the address
+ *
+ * @relates AranyaClientConfigBuilder.
  */
 AranyaError aranya_client_config_builder_set_daemon_uds_path_ext(struct AranyaClientConfigBuilder *cfg,
                                                                  const char *address,
@@ -927,6 +956,8 @@ AranyaError aranya_aqc_config_builder_cleanup_ext(struct AranyaAqcConfigBuilder 
  *
  * @param cfg a pointer to the aqc config builder
  * @param out a pointer to write the aqc config to
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_aqc_config_build(struct AranyaAqcConfigBuilder *cfg,
                                     struct AranyaAqcConfig *out);
@@ -939,6 +970,8 @@ AranyaError aranya_aqc_config_build(struct AranyaAqcConfigBuilder *cfg,
  *
  * @param cfg a pointer to the aqc config builder
  * @param out a pointer to write the aqc config to
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_aqc_config_build_ext(struct AranyaAqcConfigBuilder *cfg,
                                         struct AranyaAqcConfig *out,
@@ -950,6 +983,8 @@ AranyaError aranya_aqc_config_build_ext(struct AranyaAqcConfigBuilder *cfg,
  *
  * @param cfg a pointer to the aqc config builder
  * @param address a string with the address to bind to
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_aqc_config_builder_set_address(struct AranyaAqcConfigBuilder *cfg,
                                                   const char *address);
@@ -960,6 +995,8 @@ AranyaError aranya_aqc_config_builder_set_address(struct AranyaAqcConfigBuilder 
  *
  * @param cfg a pointer to the aqc config builder
  * @param address a string with the address to bind to
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_aqc_config_builder_set_address_ext(struct AranyaAqcConfigBuilder *cfg,
                                                       const char *address,
@@ -970,6 +1007,8 @@ AranyaError aranya_aqc_config_builder_set_address_ext(struct AranyaAqcConfigBuil
  *
  * @param cfg a pointer to the client config builder
  * @param aqc_config a pointer to a valid AQC config (see [`AranyaAqcConfigBuilder`](@ref AranyaAqcConfigBuilder))
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_client_config_builder_set_aqc_config(struct AranyaClientConfigBuilder *cfg,
                                                         const struct AranyaAqcConfig *aqc_config);
@@ -979,6 +1018,8 @@ AranyaError aranya_client_config_builder_set_aqc_config(struct AranyaClientConfi
  *
  * @param cfg a pointer to the client config builder
  * @param aqc_config a pointer to a valid AQC config (see [`AranyaAqcConfigBuilder`](@ref AranyaAqcConfigBuilder))
+ *
+ * @relates AranyaAqcConfigBuilder.
  */
 AranyaError aranya_client_config_builder_set_aqc_config_ext(struct AranyaClientConfigBuilder *cfg,
                                                             const struct AranyaAqcConfig *aqc_config,
@@ -1028,6 +1069,8 @@ AranyaError aranya_quic_sync_config_builder_cleanup_ext(struct AranyaQuicSyncCon
  * Attempts to set PSK seed generation mode value on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
  *
  * @param cfg a pointer to the quic sync config builder
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_generate(struct AranyaQuicSyncConfigBuilder *cfg);
 
@@ -1035,6 +1078,8 @@ AranyaError aranya_quic_sync_config_generate(struct AranyaQuicSyncConfigBuilder 
  * Attempts to set PSK seed generation mode value on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
  *
  * @param cfg a pointer to the quic sync config builder
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_generate_ext(struct AranyaQuicSyncConfigBuilder *cfg,
                                                  struct AranyaExtError *__ext_err);
@@ -1044,6 +1089,8 @@ AranyaError aranya_quic_sync_config_generate_ext(struct AranyaQuicSyncConfigBuil
  *
  * @param cfg a pointer to the quic sync config builder
  * @param encap_seed a pointer the encapsulated PSK seed
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_wrapped_seed(struct AranyaQuicSyncConfigBuilder *cfg,
                                                  const uint8_t *encap_seed,
@@ -1054,6 +1101,8 @@ AranyaError aranya_quic_sync_config_wrapped_seed(struct AranyaQuicSyncConfigBuil
  *
  * @param cfg a pointer to the quic sync config builder
  * @param encap_seed a pointer the encapsulated PSK seed
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_wrapped_seed_ext(struct AranyaQuicSyncConfigBuilder *cfg,
                                                      const uint8_t *encap_seed,
@@ -1061,19 +1110,23 @@ AranyaError aranya_quic_sync_config_wrapped_seed_ext(struct AranyaQuicSyncConfig
                                                      struct AranyaExtError *__ext_err);
 
 /**
- * Attempts to set raw PSK seed IKM value on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
+ * Attempts to set raw PSK seed IKM value [`AranyaSeedIkm`](@ref AranyaSeedIkm) on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
  *
- * @param cfg a pointer to the quic sync config builder
- * @param ikm a pointer the raw PSK seed IKM
+ * @param cfg a pointer to the quic sync config builder [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder)
+ * @param ikm a pointer the raw PSK seed IKM [`AranyaSeedIkm`](@ref AranyaSeedIkm)
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_raw_seed_ikm(struct AranyaQuicSyncConfigBuilder *cfg,
                                                  const struct AranyaSeedIkm *ikm);
 
 /**
- * Attempts to set raw PSK seed IKM value on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
+ * Attempts to set raw PSK seed IKM value [`AranyaSeedIkm`](@ref AranyaSeedIkm) on [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder).
  *
- * @param cfg a pointer to the quic sync config builder
- * @param ikm a pointer the raw PSK seed IKM
+ * @param cfg a pointer to the quic sync config builder [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder)
+ * @param ikm a pointer the raw PSK seed IKM [`AranyaSeedIkm`](@ref AranyaSeedIkm)
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_raw_seed_ikm_ext(struct AranyaQuicSyncConfigBuilder *cfg,
                                                      const struct AranyaSeedIkm *ikm,
@@ -1085,8 +1138,10 @@ AranyaError aranya_quic_sync_config_raw_seed_ikm_ext(struct AranyaQuicSyncConfig
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the QUIC sync config builder [`QuicSyncConfigBuilder `]
+ * @param cfg a pointer to the QUIC sync config builder [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder)
  * @param out a pointer to write the QUIC sync config to [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig)
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_build(struct AranyaQuicSyncConfigBuilder *cfg,
                                           struct AranyaQuicSyncConfig *out);
@@ -1097,8 +1152,10 @@ AranyaError aranya_quic_sync_config_build(struct AranyaQuicSyncConfigBuilder *cf
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the QUIC sync config builder [`QuicSyncConfigBuilder `]
+ * @param cfg a pointer to the QUIC sync config builder [`AranyaQuicSyncConfigBuilder`](@ref AranyaQuicSyncConfigBuilder)
  * @param out a pointer to write the QUIC sync config to [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig)
+ *
+ * @relates AranyaQuicSyncConfigBuilder.
  */
 AranyaError aranya_quic_sync_config_build_ext(struct AranyaQuicSyncConfigBuilder *cfg,
                                               struct AranyaQuicSyncConfig *out,
@@ -1151,8 +1208,10 @@ AranyaError aranya_team_config_builder_cleanup_ext(struct AranyaTeamConfigBuilde
  * [`aranya_team_config_build`](@ref aranya_team_config_build) before setting the interval with
  * this function
  *
- * @param cfg a pointer to the builder for a team config
- * @param quic set the QUIC syncer config
+ * @param cfg a pointer to the builder for a team config [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder)
+ * @param quic set the QUIC syncer config [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig)
+ *
+ * @relates AranyaTeamConfigBuilder.
  */
 AranyaError aranya_team_config_builder_set_quic_syncer(struct AranyaTeamConfigBuilder *cfg,
                                                        struct AranyaQuicSyncConfig *quic);
@@ -1164,8 +1223,10 @@ AranyaError aranya_team_config_builder_set_quic_syncer(struct AranyaTeamConfigBu
  * [`aranya_team_config_build`](@ref aranya_team_config_build) before setting the interval with
  * this function
  *
- * @param cfg a pointer to the builder for a team config
- * @param quic set the QUIC syncer config
+ * @param cfg a pointer to the builder for a team config [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder)
+ * @param quic set the QUIC syncer config [`AranyaQuicSyncConfig`](@ref AranyaQuicSyncConfig)
+ *
+ * @relates AranyaTeamConfigBuilder.
  */
 AranyaError aranya_team_config_builder_set_quic_syncer_ext(struct AranyaTeamConfigBuilder *cfg,
                                                            struct AranyaQuicSyncConfig *quic,
@@ -1177,8 +1238,10 @@ AranyaError aranya_team_config_builder_set_quic_syncer_ext(struct AranyaTeamConf
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the team config builder
- * @param out a pointer to write the team config to
+ * @param cfg a pointer to the team config builder [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder)
+ * @param out a pointer to write the team config to [`AranyaTeamConfig`](@ref AranyaTeamConfig)
+ *
+ * @relates AranyaTeamConfigBuilder.
  */
 AranyaError aranya_team_config_build(struct AranyaTeamConfigBuilder *cfg,
                                      struct AranyaTeamConfig *out);
@@ -1189,8 +1252,10 @@ AranyaError aranya_team_config_build(struct AranyaTeamConfigBuilder *cfg,
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the team config builder
- * @param out a pointer to write the team config to
+ * @param cfg a pointer to the team config builder [`AranyaTeamConfigBuilder`](@ref AranyaTeamConfigBuilder)
+ * @param out a pointer to write the team config to [`AranyaTeamConfig`](@ref AranyaTeamConfig)
+ *
+ * @relates AranyaTeamConfigBuilder.
  */
 AranyaError aranya_team_config_build_ext(struct AranyaTeamConfigBuilder *cfg,
                                          struct AranyaTeamConfig *out,
@@ -1242,7 +1307,10 @@ AranyaError aranya_sync_peer_config_builder_cleanup_ext(struct AranyaSyncPeerCon
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the builder for a sync config
+ * @param cfg a pointer to the builder for a sync config [`AranyaSyncPeerConfigBuilder`](@ref AranyaSyncPeerConfigBuilder)
+ * @param out a pointer to write the sync config to [`AranyaSyncPeerConfig`](@ref AranyaSyncPeerConfig)
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_build(struct AranyaSyncPeerConfigBuilder *cfg,
                                           struct AranyaSyncPeerConfig *out);
@@ -1253,7 +1321,10 @@ AranyaError aranya_sync_peer_config_build(struct AranyaSyncPeerConfigBuilder *cf
  * This function consumes and releases any resources associated
  * with the memory pointed to by `cfg`.
  *
- * @param cfg a pointer to the builder for a sync config
+ * @param cfg a pointer to the builder for a sync config [`AranyaSyncPeerConfigBuilder`](@ref AranyaSyncPeerConfigBuilder)
+ * @param out a pointer to write the sync config to [`AranyaSyncPeerConfig`](@ref AranyaSyncPeerConfig)
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_build_ext(struct AranyaSyncPeerConfigBuilder *cfg,
                                               struct AranyaSyncPeerConfig *out,
@@ -1268,6 +1339,8 @@ AranyaError aranya_sync_peer_config_build_ext(struct AranyaSyncPeerConfigBuilder
  *
  * @param cfg a pointer to the builder for a sync config
  * @param interval Set the interval at which syncing occurs
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_interval(struct AranyaSyncPeerConfigBuilder *cfg,
                                                          AranyaDuration interval);
@@ -1281,6 +1354,8 @@ AranyaError aranya_sync_peer_config_builder_set_interval(struct AranyaSyncPeerCo
  *
  * @param cfg a pointer to the builder for a sync config
  * @param interval Set the interval at which syncing occurs
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_interval_ext(struct AranyaSyncPeerConfigBuilder *cfg,
                                                              AranyaDuration interval,
@@ -1294,6 +1369,8 @@ AranyaError aranya_sync_peer_config_builder_set_interval_ext(struct AranyaSyncPe
  * By default, the peer is synced with immediately.
  *
  * @param cfg a pointer to the builder for a sync config
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_sync_now(struct AranyaSyncPeerConfigBuilder *cfg);
 
@@ -1305,6 +1382,8 @@ AranyaError aranya_sync_peer_config_builder_set_sync_now(struct AranyaSyncPeerCo
  * By default, the peer is synced with immediately.
  *
  * @param cfg a pointer to the builder for a sync config
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_sync_now_ext(struct AranyaSyncPeerConfigBuilder *cfg,
                                                              struct AranyaExtError *__ext_err);
@@ -1316,6 +1395,8 @@ AranyaError aranya_sync_peer_config_builder_set_sync_now_ext(struct AranyaSyncPe
  *
  * By default, the peer is synced with immediately.
  * @param cfg a pointer to the builder for a sync config
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_sync_later(struct AranyaSyncPeerConfigBuilder *cfg);
 
@@ -1326,6 +1407,8 @@ AranyaError aranya_sync_peer_config_builder_set_sync_later(struct AranyaSyncPeer
  *
  * By default, the peer is synced with immediately.
  * @param cfg a pointer to the builder for a sync config
+ *
+ * @relates AranyaSyncPeerConfigBuilder.
  */
 AranyaError aranya_sync_peer_config_builder_set_sync_later_ext(struct AranyaSyncPeerConfigBuilder *cfg,
                                                                struct AranyaExtError *__ext_err);

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -238,7 +238,7 @@ const _: () = {
     assert!(ARANYA_ID_LEN == size_of::<aranya_crypto::Id>());
 };
 
-// Aranya ID
+/// Cryptographically secure Aranya ID.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct Id {
@@ -575,10 +575,11 @@ pub fn get_device_id(client: &mut Client) -> Result<DeviceId, imp::Error> {
 }
 
 /// Configuration info for Aranya.
+/// Use a [`ClientConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 56, align = 8)]
 pub type ClientConfig = Safe<imp::ClientConfig>;
 
-/// Configuration info builder for Aranya.
+/// Configuration info builder for an Aranya client config [`ClientConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 72, align = 8)]
 pub type ClientConfigBuilder = Safe<imp::ClientConfigBuilder>;
@@ -590,6 +591,8 @@ pub type ClientConfigBuilder = Safe<imp::ClientConfigBuilder>;
 ///
 /// @param cfg a pointer to the client config builder
 /// @param out a pointer to write the client config to
+///
+/// @relates AranyaClientConfigBuilder.
 pub fn client_config_build(
     cfg: OwnedPtr<ClientConfigBuilder>,
     out: &mut MaybeUninit<ClientConfig>,
@@ -603,6 +606,8 @@ pub fn client_config_build(
 ///
 /// @param cfg a pointer to the client config builder
 /// @param address a string containing the address
+///
+/// @relates AranyaClientConfigBuilder.
 pub fn client_config_builder_set_daemon_uds_path(
     cfg: &mut ClientConfigBuilder,
     address: *const c_char,
@@ -611,10 +616,11 @@ pub fn client_config_builder_set_daemon_uds_path(
 }
 
 /// Configuration info for Aranya QUIC Channels.
+/// Use a [`AqcConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 40, align = 8)]
 pub type AqcConfig = Safe<imp::AqcConfig>;
 
-/// Configuration info builder for Aranya QUIC Channels.
+/// Configuration info builder for Aranya QUIC Channels config [`AqcConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 24, align = 8)]
 pub type AqcConfigBuilder = Safe<imp::AqcConfigBuilder>;
@@ -626,6 +632,8 @@ pub type AqcConfigBuilder = Safe<imp::AqcConfigBuilder>;
 ///
 /// @param cfg a pointer to the aqc config builder
 /// @param out a pointer to write the aqc config to
+///
+/// @relates AranyaAqcConfigBuilder.
 pub fn aqc_config_build(
     cfg: OwnedPtr<AqcConfigBuilder>,
     out: &mut MaybeUninit<AqcConfig>,
@@ -640,6 +648,8 @@ pub fn aqc_config_build(
 ///
 /// @param cfg a pointer to the aqc config builder
 /// @param address a string with the address to bind to
+///
+/// @relates AranyaAqcConfigBuilder.
 pub fn aqc_config_builder_set_address(cfg: &mut AqcConfigBuilder, address: *const c_char) {
     cfg.addr(address);
 }
@@ -648,13 +658,19 @@ pub fn aqc_config_builder_set_address(cfg: &mut AqcConfigBuilder, address: *cons
 ///
 /// @param cfg a pointer to the client config builder
 /// @param aqc_config a pointer to a valid AQC config (see [`AqcConfigBuilder`])
+///
+/// @relates AranyaAqcConfigBuilder.
 pub fn client_config_builder_set_aqc_config(cfg: &mut ClientConfigBuilder, aqc_config: &AqcConfig) {
     cfg.aqc((**aqc_config).clone());
 }
 
+/// QUIC syncer configuration.
+/// Use a [`QuicSyncConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type QuicSyncConfig = Safe<imp::QuicSyncConfig>;
 
+/// A builder for initializing a [`QuicSyncConfig`].
+/// The [`QuicSyncConfig`] is an optional part of initializing a [`TeamConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type QuicSyncConfigBuilder = Safe<imp::QuicSyncConfigBuilder>;
@@ -662,6 +678,8 @@ pub type QuicSyncConfigBuilder = Safe<imp::QuicSyncConfigBuilder>;
 /// Attempts to set PSK seed generation mode value on [`QuicSyncConfigBuilder`].
 ///
 /// @param cfg a pointer to the quic sync config builder
+///
+/// @relates AranyaQuicSyncConfigBuilder.
 pub fn quic_sync_config_generate(cfg: &mut QuicSyncConfigBuilder) -> Result<(), imp::Error> {
     cfg.generate();
     Ok(())
@@ -671,6 +689,8 @@ pub fn quic_sync_config_generate(cfg: &mut QuicSyncConfigBuilder) -> Result<(), 
 ///
 /// @param cfg a pointer to the quic sync config builder
 /// @param encap_seed a pointer the encapsulated PSK seed
+///
+/// @relates AranyaQuicSyncConfigBuilder.
 pub fn quic_sync_config_wrapped_seed(
     cfg: &mut QuicSyncConfigBuilder,
     encap_seed: &[u8],
@@ -686,10 +706,12 @@ pub struct SeedIkm {
     bytes: [u8; ARANYA_SEED_IKM_LEN],
 }
 
-/// Attempts to set raw PSK seed IKM value on [`QuicSyncConfigBuilder`].
+/// Attempts to set raw PSK seed IKM value [`SeedIkm`] on [`QuicSyncConfigBuilder`].
 ///
-/// @param cfg a pointer to the quic sync config builder
-/// @param ikm a pointer the raw PSK seed IKM
+/// @param cfg a pointer to the quic sync config builder [`QuicSyncConfigBuilder`]
+/// @param ikm a pointer the raw PSK seed IKM [`SeedIkm`]
+///
+/// @relates AranyaQuicSyncConfigBuilder.
 pub fn quic_sync_config_raw_seed_ikm(
     cfg: &mut QuicSyncConfigBuilder,
     ikm: &SeedIkm,
@@ -703,8 +725,10 @@ pub fn quic_sync_config_raw_seed_ikm(
 /// This function consumes and releases any resources associated
 /// with the memory pointed to by `cfg`.
 ///
-/// @param cfg a pointer to the QUIC sync config builder [`QuicSyncConfigBuilder `]
+/// @param cfg a pointer to the QUIC sync config builder [`QuicSyncConfigBuilder`]
 /// @param out a pointer to write the QUIC sync config to [`QuicSyncConfig`]
+///
+/// @relates AranyaQuicSyncConfigBuilder.
 pub fn quic_sync_config_build(
     cfg: OwnedPtr<QuicSyncConfigBuilder>,
     out: &mut MaybeUninit<QuicSyncConfig>,
@@ -714,9 +738,12 @@ pub fn quic_sync_config_build(
     Ok(())
 }
 
+/// Team configuration.
+/// Use a [`TeamConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type TeamConfig = Safe<imp::TeamConfig>;
 
+/// A builder for initializing a [`TeamConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type TeamConfigBuilder = Safe<imp::TeamConfigBuilder>;
@@ -727,8 +754,10 @@ pub type TeamConfigBuilder = Safe<imp::TeamConfigBuilder>;
 /// [`team_config_build`] before setting the interval with
 /// this function
 ///
-/// @param cfg a pointer to the builder for a team config
-/// @param quic set the QUIC syncer config
+/// @param cfg a pointer to the builder for a team config [`TeamConfigBuilder`]
+/// @param quic set the QUIC syncer config [`QuicSyncConfig`]
+///
+/// @relates AranyaTeamConfigBuilder.
 pub fn team_config_builder_set_quic_syncer(
     cfg: &mut TeamConfigBuilder,
     quic: OwnedPtr<QuicSyncConfig>,
@@ -743,8 +772,10 @@ pub fn team_config_builder_set_quic_syncer(
 /// This function consumes and releases any resources associated
 /// with the memory pointed to by `cfg`.
 ///
-/// @param cfg a pointer to the team config builder
-/// @param out a pointer to write the team config to
+/// @param cfg a pointer to the team config builder [`TeamConfigBuilder`]
+/// @param out a pointer to write the team config to [`TeamConfig`]
+///
+/// @relates AranyaTeamConfigBuilder.
 pub fn team_config_build(
     cfg: OwnedPtr<TeamConfigBuilder>,
     out: &mut MaybeUninit<TeamConfig>,
@@ -755,10 +786,11 @@ pub fn team_config_build(
 }
 
 /// Sync Peer config.
+/// Use a [`SyncPeerConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 32, align = 8)]
 pub type SyncPeerConfig = Safe<imp::SyncPeerConfig>;
 
-/// Builder for a Sync Peer config.
+/// Builder for a Sync Peer config [`SyncPeerConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 40, align = 8)]
 pub type SyncPeerConfigBuilder = Safe<imp::SyncPeerConfigBuilder>;
@@ -768,7 +800,10 @@ pub type SyncPeerConfigBuilder = Safe<imp::SyncPeerConfigBuilder>;
 /// This function consumes and releases any resources associated
 /// with the memory pointed to by `cfg`.
 ///
-/// @param cfg a pointer to the builder for a sync config
+/// @param cfg a pointer to the builder for a sync config [`SyncPeerConfigBuilder`]
+/// @param out a pointer to write the sync config to [`SyncPeerConfig`]
+///
+/// @relates AranyaSyncPeerConfigBuilder.
 pub fn sync_peer_config_build(
     cfg: OwnedPtr<SyncPeerConfigBuilder>,
     out: &mut MaybeUninit<SyncPeerConfig>,
@@ -786,6 +821,8 @@ pub fn sync_peer_config_build(
 ///
 /// @param cfg a pointer to the builder for a sync config
 /// @param interval Set the interval at which syncing occurs
+///
+/// @relates AranyaSyncPeerConfigBuilder.
 pub fn sync_peer_config_builder_set_interval(cfg: &mut SyncPeerConfigBuilder, interval: Duration) {
     cfg.interval(interval);
 }
@@ -797,6 +834,8 @@ pub fn sync_peer_config_builder_set_interval(cfg: &mut SyncPeerConfigBuilder, in
 /// By default, the peer is synced with immediately.
 ///
 /// @param cfg a pointer to the builder for a sync config
+///
+/// @relates AranyaSyncPeerConfigBuilder.
 // TODO: aranya-core#129
 pub fn sync_peer_config_builder_set_sync_now(cfg: &mut SyncPeerConfigBuilder) {
     cfg.sync_now(true);
@@ -808,6 +847,8 @@ pub fn sync_peer_config_builder_set_sync_now(cfg: &mut SyncPeerConfigBuilder) {
 ///
 /// By default, the peer is synced with immediately.
 /// @param cfg a pointer to the builder for a sync config
+///
+/// @relates AranyaSyncPeerConfigBuilder.
 // TODO: aranya-core#129
 pub fn sync_peer_config_builder_set_sync_later(cfg: &mut SyncPeerConfigBuilder) {
     cfg.sync_now(false);

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -548,7 +548,6 @@ pub fn id_to_str(
 
 /// Decodes `str` into an [`Id`].
 ///
-///
 /// @param str pointer to a null-terminated string.
 ///
 /// @relates AranyaId.
@@ -575,6 +574,7 @@ pub fn get_device_id(client: &mut Client) -> Result<DeviceId, imp::Error> {
 }
 
 /// Configuration info for Aranya.
+///
 /// Use a [`ClientConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 56, align = 8)]
 pub type ClientConfig = Safe<imp::ClientConfig>;
@@ -616,6 +616,7 @@ pub fn client_config_builder_set_daemon_uds_path(
 }
 
 /// Configuration info for Aranya QUIC Channels.
+///
 /// Use a [`AqcConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 40, align = 8)]
 pub type AqcConfig = Safe<imp::AqcConfig>;
@@ -665,11 +666,13 @@ pub fn client_config_builder_set_aqc_config(cfg: &mut ClientConfigBuilder, aqc_c
 }
 
 /// QUIC syncer configuration.
+///
 /// Use a [`QuicSyncConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type QuicSyncConfig = Safe<imp::QuicSyncConfig>;
 
 /// A builder for initializing a [`QuicSyncConfig`].
+///
 /// The [`QuicSyncConfig`] is an optional part of initializing a [`TeamConfig`].
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 288, align = 8)]
@@ -739,6 +742,7 @@ pub fn quic_sync_config_build(
 }
 
 /// Team configuration.
+///
 /// Use a [`TeamConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 288, align = 8)]
 pub type TeamConfig = Safe<imp::TeamConfig>;
@@ -786,6 +790,7 @@ pub fn team_config_build(
 }
 
 /// Sync Peer config.
+///
 /// Use a [`SyncPeerConfigBuilder`] to construct this object.
 #[aranya_capi_core::opaque(size = 32, align = 8)]
 pub type SyncPeerConfig = Safe<imp::SyncPeerConfig>;
@@ -1026,6 +1031,7 @@ pub fn create_team(client: &mut Client, cfg: &TeamConfig) -> Result<TeamId, imp:
 }
 
 /// Return random bytes from Aranya's CSPRNG.
+///
 /// This method can be used to generate a PSK seed IKM for the QUIC syncer.
 ///
 /// @param[in] client the Aranya Client [`Client`].
@@ -1042,6 +1048,7 @@ pub unsafe fn rand(client: &mut Client, buf: &mut [MaybeUninit<u8>]) {
 }
 
 /// Return serialized PSK seed encrypted for another device on the team.
+///
 /// The PSK seed will be encrypted using the public encryption key of the specified device on the team.
 ///
 /// Returns an `AranyaBufferTooSmall` error if the output buffer is too small to hold the seed bytes.


### PR DESCRIPTION
The existing Doxygen docs are not detailed enough for a reader to easily figure out how to initialize the various config objects in the Aranya client's C API.

These docs describe how to use the builder objects to initialize config objects.