### PR TITLE
c example: replace malloc with calloc

### DIFF
--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -224,7 +224,7 @@ AranyaError init_client(Client *c, const char *name, const char *daemon_addr,
     // `pk_len` is intentionally set to small size to show how to
     // handle reallocations.
     c->pk_len = 1;
-    c->pk     = malloc(c->pk_len);
+    c->pk     = calloc(c->pk_len, 1);
     if (c->pk == NULL) {
         abort();
     }


### PR DESCRIPTION
Replace `malloc()` with `calloc()` in the C example.
This task was mostly completed already but I found one remaining `malloc()`.