### PR TITLE
quic sync: cleanup daemon quic sync cfg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ cargo make run-capi-example
 ### Daemon Development
 
 The daemon requires a configuration file (see
-`crates/aranya-daemon/example.json`):
+`crates/aranya-daemon/test_configs/example.json`):
 
 ```bash
 cargo build --bin aranya-daemon --release

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This snippet can be found in the
 [Rust example](examples/rust/src/main.rs#L198).
 
 Before starting your application, run the daemon by providing the path to a
-[configuration file](crates/aranya-daemon/example.json). Find more details on
+[configuration file](crates/aranya-daemon/test_configs/example.json). Find more details on
 configuring and running the daemon in the `aranya-daemon`
 [README](crates/aranya-daemon/README.md).
 
@@ -213,7 +213,7 @@ This snippet has been modified for simplicity. For actual usage,
 see the [C example](examples/c/example.c#L169).
 
 Before starting your application, run the daemon by providing the path to a
-[configuration file](crates/aranya-daemon/example.json). Find more details on
+[configuration file](crates/aranya-daemon/test_configs/example.json). Find more details on
 configuring and running the daemon in the `aranya-daemon`
 [README](crates/aranya-daemon/README.md).
 
@@ -229,7 +229,7 @@ The examples go through the following steps:
 
 Step 1: Build or download the prebuilt executable from the latest Aranya
 release. After providing a unique configuration file (see
-[example.json](crates/aranya-daemon/example.json)) for each device, run the
+[example.json](crates/aranya-daemon/test_configs/example.json)) for each device, run the
 daemons.
 
 Step 2. The `Owner` initializes the team

--- a/crates/aranya-client/tests/common/mod.rs
+++ b/crates/aranya-client/tests/common/mod.rs
@@ -175,7 +175,7 @@ impl DeviceCtx {
         let addr_any = Addr::from((Ipv4Addr::LOCALHOST, 0));
 
         // Setup daemon config.
-        let quic_sync = Some(daemon_cfg::QuicSyncConfig {});
+        let quic_sync = Some(daemon_cfg::QuicSyncConfig::default());
 
         let cfg = Config {
             name: name.into(),

--- a/crates/aranya-daemon/README.md
+++ b/crates/aranya-daemon/README.md
@@ -36,7 +36,7 @@ Create a config file for the daemon before running it. Refer to
 this documentation on the JSON config file parameters:
 [config](src/config.rs).
 
-An example daemon configuration file can be found [here](example.json).
+An example daemon configuration file can be found [here](test_configs/example.json).
 
 ## Running the daemon
 

--- a/crates/aranya-daemon/src/config.rs
+++ b/crates/aranya-daemon/src/config.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
 };
 
@@ -113,6 +114,24 @@ pub struct Config {
     /// QUIC syncer config
     #[serde(default)]
     pub quic_sync: Option<QuicSyncConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let sync_addr = Addr::from(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0));
+        Self {
+            name: Default::default(),
+            runtime_dir: Default::default(),
+            state_dir: Default::default(),
+            cache_dir: Default::default(),
+            logs_dir: Default::default(),
+            config_dir: Default::default(),
+            sync_addr,
+            afc: Default::default(),
+            aqc: Default::default(),
+            quic_sync: Some(QuicSyncConfig::default()),
+        }
+    }
 }
 
 impl Config {
@@ -327,6 +346,20 @@ mod tests {
         };
         assert_eq!(got, want);
         assert_eq!(want.quic_sync.unwrap().enabled, false);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_default() -> Result<()> {
+        const DIR: &str = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(DIR)
+            .join("test_configs")
+            .join("missing_quic_sync.json");
+        let load = Config::load(path)?;
+        assert_eq!(load.quic_sync.unwrap().enabled, true);
+        let default = Config::default();
+        assert_eq!(default.quic_sync.unwrap().enabled, true);
 
         Ok(())
     }

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -533,7 +533,6 @@ mod tests {
             logs_dir: work_dir.join("logs"),
             config_dir: work_dir.join("config"),
             sync_addr: any,
-            quic_sync: None,
             afc: Some(AfcConfig {
                 shm_path: "/test_daemon1".to_owned(),
                 unlink_on_startup: true,
@@ -542,6 +541,7 @@ mod tests {
                 max_chans: 100,
             }),
             aqc: None,
+            ..Config::default()
         };
         for dir in [
             &cfg.runtime_dir,

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -30,7 +30,7 @@ use crate::{
     api::{ApiKey, DaemonApiServer, QSData},
     aqc::Aqc,
     aranya,
-    config::Config,
+    config::{Config, QuicSyncConfig},
     keystore::{AranyaStore, LocalStore},
     policy,
     sync::task::{
@@ -135,7 +135,7 @@ impl Daemon {
 
         async move {
             // TODO: Fix this when other syncer types are supported
-            let Some(_qs_config) = &cfg.quic_sync else {
+            if let Some(QuicSyncConfig { enabled: false }) = &cfg.quic_sync {
                 anyhow::bail!("Supply a valid QUIC sync config")
             };
 
@@ -481,7 +481,7 @@ mod tests {
             logs_dir: work_dir.join("logs"),
             config_dir: work_dir.join("config"),
             sync_addr: any,
-            quic_sync: Some(QuicSyncConfig {}),
+            quic_sync: Some(QuicSyncConfig::default()),
             afc: Some(AfcConfig {
                 shm_path: "/test_daemon1".to_owned(),
                 unlink_on_startup: true,

--- a/crates/aranya-daemon/test_configs/disabled_quic_sync.json
+++ b/crates/aranya-daemon/test_configs/disabled_quic_sync.json
@@ -2,8 +2,6 @@
     // The name of the daemon, used for logging and debugging
     // purposes.
     "name": "name",
-
-
     // The directory where the daemon stores non-essential
     // runtime files and other file objects (sockets, etc.).
     //
@@ -19,7 +17,6 @@
     // See also: systemd `RuntimeDirectory=` and
     // `$XDG_RUNTIME_DIR`.
     "runtime_dir": "/var/run/aranya",
-
     // The directory where the daemon stores non-portable data
     // that should persist between application restarts.
     //
@@ -35,7 +32,6 @@
     // See also: systemd `StateDirectory=` and
     // `$XDG_STATE_HOME`.
     "state_dir": "/var/lib/aranya",
-
     // The directory where the daemon stores non-essential data
     // files.
     //
@@ -51,7 +47,6 @@
     // See also: systemd `CacheDirectory=` and
     // `$XDG_CACHE_HOME`.
     "cache_dir": "/var/cache/aranya",
-
     // The directory where the daemon writes log files.
     //
     // # Multiple Daemon Support
@@ -65,7 +60,6 @@
     //
     // See also: systemd `LogsDirectory=`.
     "logs_dir": "/var/log/aranya",
-
     // The directory where the daemon can find additional
     // configuration files.
     //
@@ -81,9 +75,10 @@
     // See also: systemd `ConfigDirectory=` and
     // `$XDG_CONFIG_HOME`.
     "config_dir": "/etc/aranya",
-
     // Aranya sync server address.
     "sync_addr": "0.0.0.0:4321",
-
-    "quic_sync": {},
+    // QUIC syncer configuration.
+    "quic_sync": {
+        "enabled": false,
+    },
 }

--- a/crates/aranya-daemon/test_configs/example.json
+++ b/crates/aranya-daemon/test_configs/example.json
@@ -1,0 +1,84 @@
+{
+    // The name of the daemon, used for logging and debugging
+    // purposes.
+    "name": "name",
+    // The directory where the daemon stores non-essential
+    // runtime files and other file objects (sockets, etc.).
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/run/aranya`.
+    //
+    // See also: systemd `RuntimeDirectory=` and
+    // `$XDG_RUNTIME_DIR`.
+    "runtime_dir": "/var/run/aranya",
+    // The directory where the daemon stores non-portable data
+    // that should persist between application restarts.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/lib/aranya`.
+    //
+    // See also: systemd `StateDirectory=` and
+    // `$XDG_STATE_HOME`.
+    "state_dir": "/var/lib/aranya",
+    // The directory where the daemon stores non-essential data
+    // files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/cache/aranya`.
+    //
+    // See also: systemd `CacheDirectory=` and
+    // `$XDG_CACHE_HOME`.
+    "cache_dir": "/var/cache/aranya",
+    // The directory where the daemon writes log files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/log/aranya`.
+    //
+    // See also: systemd `LogsDirectory=`.
+    "logs_dir": "/var/log/aranya",
+    // The directory where the daemon can find additional
+    // configuration files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/etc/aranya`.
+    //
+    // See also: systemd `ConfigDirectory=` and
+    // `$XDG_CONFIG_HOME`.
+    "config_dir": "/etc/aranya",
+    // Aranya sync server address.
+    "sync_addr": "0.0.0.0:4321",
+    // QUIC syncer configuration.
+    "quic_sync": {
+        "enabled": true,
+    },
+}

--- a/crates/aranya-daemon/test_configs/missing_quic_sync.json
+++ b/crates/aranya-daemon/test_configs/missing_quic_sync.json
@@ -1,0 +1,80 @@
+{
+    // The name of the daemon, used for logging and debugging
+    // purposes.
+    "name": "name",
+    // The directory where the daemon stores non-essential
+    // runtime files and other file objects (sockets, etc.).
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/run/aranya`.
+    //
+    // See also: systemd `RuntimeDirectory=` and
+    // `$XDG_RUNTIME_DIR`.
+    "runtime_dir": "/var/run/aranya",
+    // The directory where the daemon stores non-portable data
+    // that should persist between application restarts.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/lib/aranya`.
+    //
+    // See also: systemd `StateDirectory=` and
+    // `$XDG_STATE_HOME`.
+    "state_dir": "/var/lib/aranya",
+    // The directory where the daemon stores non-essential data
+    // files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/cache/aranya`.
+    //
+    // See also: systemd `CacheDirectory=` and
+    // `$XDG_CACHE_HOME`.
+    "cache_dir": "/var/cache/aranya",
+    // The directory where the daemon writes log files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/var/log/aranya`.
+    //
+    // See also: systemd `LogsDirectory=`.
+    "logs_dir": "/var/log/aranya",
+    // The directory where the daemon can find additional
+    // configuration files.
+    //
+    // # Multiple Daemon Support
+    //
+    // This directory should be unique for each instance of the
+    // daemon.
+    //
+    // # Example
+    //
+    // For example, this could be `/etc/aranya`.
+    //
+    // See also: systemd `ConfigDirectory=` and
+    // `$XDG_CONFIG_HOME`.
+    "config_dir": "/etc/aranya",
+    // Aranya sync server address.
+    "sync_addr": "0.0.0.0:4321",
+}

--- a/examples/c/example.bash
+++ b/examples/c/example.bash
@@ -54,7 +54,7 @@ for device in "${devices[@]}"; do
     "logs_dir": "${out}/${device}/log",
     "config_dir": "${out}/${device}/config",
     "sync_addr": "127.0.0.1:${port}",
-    "quic_sync": {},
+    "quic_sync": { "enabled": true },
 }
 EOF
     port=$((port + 1))

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -99,7 +99,7 @@ impl ClientCtx {
                 logs_dir: {logs_dir:?}
                 config_dir: {config_dir:?}
                 sync_addr: "127.0.0.1:0"
-                quic_sync: {{ }}
+                quic_sync: {{ "enabled": true }}
                 "#
             );
             fs::write(&cfg_path, buf).await?;


### PR DESCRIPTION
Enable the QUIC syncer by default.
Replace `"quic_sync": {}` with;
`"quic_sync": { "enabled": true }`
or
`"quic_sync": { "enabled": false }`

Add tests for various possible JSON configurations to ensure the default is set properly and the QUIC syncer must be explicitly disabled for it not to initialize.