### PR TITLE
client: eagerly implement Debug trait in public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "bytes",
  "ciborium",
  "clap",
+ "derive-where",
  "futures-util",
  "postcard",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.85"
 
 [workspace.lints.rust]
 # missing_docs = "warn"
+missing_debug_implementations = "warn"
 rust_2018_idioms = { level = "warn", priority = -1 }
 unsafe_op_in_unsafe_fn = "warn"
 unused_lifetimes = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ backon = { version = "1.2.0" }
 bytes = { version = "1.0" }
 ciborium = { version = "0.2" }
 clap = { version = "4", features = ["derive"] }
+derive-where = { version = "1" }
 futures-lite = { version = "2.6.0" }
 futures-util = { version = "0.3.30" }
 heapless = { version = "0.8", default-features = false }

--- a/crates/aranya-client-capi/src/imp/aqc.rs
+++ b/crates/aranya-client-capi/src/imp/aqc.rs
@@ -8,6 +8,7 @@ use aranya_client::aqc;
 use bytes::{Buf as _, Bytes};
 
 /// An AQC channel that can both send and receive data.
+#[derive(Debug)]
 pub struct AqcBidiChannel {
     pub(crate) inner: aqc::AqcBidiChannel,
 }
@@ -23,6 +24,7 @@ impl AqcBidiChannel {
 }
 
 /// An AQC channel that can only send data.
+#[derive(Debug)]
 pub struct AqcSendChannel {
     pub(crate) inner: aqc::AqcSendChannel,
 }
@@ -38,6 +40,7 @@ impl AqcSendChannel {
 }
 
 /// An AQC channel that can only receive data.
+#[derive(Debug)]
 pub struct AqcReceiveChannel {
     pub(crate) inner: aqc::AqcReceiveChannel,
 }
@@ -56,6 +59,7 @@ impl AqcReceiveChannel {
 ///
 /// This needs to be destructured before it can be used, since C doesn't have
 /// dataful enums.
+#[derive(Debug)]
 pub struct AqcPeerChannel {
     pub(crate) inner: aqc::AqcPeerChannel,
 }
@@ -71,6 +75,7 @@ impl AqcPeerChannel {
 }
 
 /// An AQC stream that can both send and receive data.
+#[derive(Debug)]
 pub struct AqcBidiStream {
     pub(crate) inner: aqc::AqcBidiStream,
     pub(crate) data: Bytes,
@@ -90,6 +95,7 @@ impl AqcBidiStream {
 }
 
 /// An AQC stream that can only send data.
+#[derive(Debug)]
 pub struct AqcSendStream {
     pub(crate) inner: aqc::AqcSendStream,
 }
@@ -105,6 +111,7 @@ impl AqcSendStream {
 }
 
 /// An AQC stream that can only receive data.
+#[derive(Debug)]
 pub struct AqcReceiveStream {
     pub(crate) inner: aqc::AqcReceiveStream,
     pub(crate) data: Bytes,

--- a/crates/aranya-client-capi/src/imp/client.rs
+++ b/crates/aranya-client-capi/src/imp/client.rs
@@ -3,6 +3,7 @@ use std::mem::MaybeUninit;
 use aranya_capi_core::safe::{TypeId, Typed};
 
 /// An instance of an Aranya Client, along with an async runtime.
+#[derive(Debug)]
 pub struct Client {
     pub(crate) inner: aranya_client::Client,
     pub(crate) rt: tokio::runtime::Runtime,

--- a/crates/aranya-client-capi/src/imp/config/team.rs
+++ b/crates/aranya-client-capi/src/imp/config/team.rs
@@ -15,7 +15,7 @@ pub(crate) use quic_sync::{
 };
 
 /// A team config required to create a new Aranya team.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CreateTeamConfig {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -36,7 +36,7 @@ impl Typed for CreateTeamConfig {
 }
 
 /// Builder for constructing a [`CreateTeamConfig`].
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct CreateTeamConfigBuilder {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -69,7 +69,7 @@ impl Builder for CreateTeamConfigBuilder {
 }
 
 /// Configuration for adding an existing Aranya team to a device.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AddTeamConfig {
     team_id: TeamId,
     quic_sync: Option<AddTeamQuicSyncConfig>,
@@ -91,7 +91,7 @@ impl Typed for AddTeamConfig {
 }
 
 /// Builder for constructing an [`AddTeamConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AddTeamConfigBuilder {
     team_id: Option<TeamId>,
     quic_sync: Option<AddTeamQuicSyncConfig>,

--- a/crates/aranya-client-capi/src/imp/config/team.rs
+++ b/crates/aranya-client-capi/src/imp/config/team.rs
@@ -15,7 +15,7 @@ pub(crate) use quic_sync::{
 };
 
 /// A team config required to create a new Aranya team.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct CreateTeamConfig {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -69,7 +69,7 @@ impl Builder for CreateTeamConfigBuilder {
 }
 
 /// Configuration for adding an existing Aranya team to a device.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AddTeamConfig {
     team_id: TeamId,
     quic_sync: Option<AddTeamQuicSyncConfig>,

--- a/crates/aranya-client-capi/src/imp/config/team.rs
+++ b/crates/aranya-client-capi/src/imp/config/team.rs
@@ -36,7 +36,7 @@ impl Typed for CreateTeamConfig {
 }
 
 /// Builder for constructing a [`CreateTeamConfig`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct CreateTeamConfigBuilder {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }

--- a/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
+++ b/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
@@ -11,7 +11,7 @@ use super::Error;
 use crate::api::defs::{self};
 
 /// QUIC syncer configuration for CreateTeam() operation.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateTeamQuicSyncConfig {
     mode: CreateSeedMode,
 }
@@ -46,7 +46,7 @@ impl From<CreateTeamQuicSyncConfig> for aranya_client::CreateTeamQuicSyncConfig 
 }
 
 /// QUIC syncer configuration for AddTeam() operation.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AddTeamQuicSyncConfig {
     mode: AddSeedMode,
 }

--- a/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
+++ b/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
@@ -11,7 +11,7 @@ use super::Error;
 use crate::api::defs::{self};
 
 /// QUIC syncer configuration for CreateTeam() operation.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct CreateTeamQuicSyncConfig {
     mode: CreateSeedMode,
 }
@@ -46,7 +46,7 @@ impl From<CreateTeamQuicSyncConfig> for aranya_client::CreateTeamQuicSyncConfig 
 }
 
 /// QUIC syncer configuration for AddTeam() operation.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AddTeamQuicSyncConfig {
     mode: AddSeedMode,
 }
@@ -81,7 +81,7 @@ impl From<AddTeamQuicSyncConfig> for aranya_client::AddTeamQuicSyncConfig {
 }
 
 /// Builder for constructing a [`CreateTeamQuicSyncConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CreateTeamQuicSyncConfigBuilder {
     mode: CreateSeedMode,
 }
@@ -132,7 +132,7 @@ impl Typed for CreateTeamQuicSyncConfigBuilder {
 }
 
 /// Builder for constructing an [`AddTeamQuicSyncConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AddTeamQuicSyncConfigBuilder {
     mode: Option<AddSeedMode>,
 }

--- a/crates/aranya-client-capi/src/imp/error.rs
+++ b/crates/aranya-client-capi/src/imp/error.rs
@@ -84,7 +84,7 @@ impl From<WriteCStrError> for Error {
 }
 
 /// Underlying type for [`ExtError`][crate::api::ExtError].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ExtError {
     err: Option<Error>,
 }

--- a/crates/aranya-client/src/aqc/net.rs
+++ b/crates/aranya-client/src/aqc/net.rs
@@ -65,7 +65,7 @@ pub(crate) struct AqcClient {
     daemon: DaemonApiClient,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct ClientState {
     /// Quic client used to create channels with peers.
     quic_client: Client,
@@ -463,14 +463,14 @@ pub enum TryReceiveError<E = AqcError> {
     Closed,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 struct AqcChannelInfo {
     label_id: LabelId,
     channel_id: AqcChannelId,
 }
 
 /// An AQC Channel ID.
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Copy, Clone)]
 enum AqcChannelId {
     Bidi(BidiChannelId),
     Uni(UniChannelId),

--- a/crates/aranya-client/src/aqc/net.rs
+++ b/crates/aranya-client/src/aqc/net.rs
@@ -463,14 +463,14 @@ pub enum TryReceiveError<E = AqcError> {
     Closed,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 struct AqcChannelInfo {
     label_id: LabelId,
     channel_id: AqcChannelId,
 }
 
 /// An AQC Channel ID.
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum AqcChannelId {
     Bidi(BidiChannelId),
     Uni(UniChannelId),

--- a/crates/aranya-client/src/aqc/net.rs
+++ b/crates/aranya-client/src/aqc/net.rs
@@ -65,7 +65,7 @@ pub(crate) struct AqcClient {
     daemon: DaemonApiClient,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct ClientState {
     /// Quic client used to create channels with peers.
     quic_client: Client,

--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -14,7 +14,6 @@ use aranya_daemon_api::{
 };
 use aranya_util::Addr;
 use buggy::BugExt as _;
-use serde::{Deserialize, Serialize};
 use tarpc::context;
 use tokio::{fs, net::UnixStream};
 use tracing::{debug, error, info, instrument};
@@ -26,7 +25,7 @@ use crate::{
 };
 
 /// List of device IDs.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Devices {
     data: Vec<DeviceId>,
 }
@@ -44,7 +43,7 @@ impl Devices {
 }
 
 /// List of labels.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Labels {
     data: Vec<Label>,
 }
@@ -62,7 +61,7 @@ impl Labels {
 }
 
 /// Builds a [`Client`].
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[derive(Debug, Default)]
 pub struct ClientBuilder<'a> {
     /// The UDS that the daemon is listening on.
     #[cfg(unix)]

--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// List of device IDs.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Devices {
     data: Vec<DeviceId>,
 }
@@ -43,7 +43,7 @@ impl Devices {
 }
 
 /// List of labels.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Labels {
     data: Vec<Label>,
 }
@@ -300,7 +300,7 @@ impl Client {
 /// - creating/assigning/deleting labels.
 /// - creating/deleting fast channels.
 /// - assigning network identifiers to devices.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Team<'a> {
     client: &'a Client,
     team_id: TeamId,
@@ -505,7 +505,7 @@ impl Team<'_> {
 /// Queries the Aranya fact database.
 ///
 /// The fact database is updated when actions/effects are processed for a team.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Queries<'a> {
     client: &'a Client,
     team_id: TeamId,

--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -14,6 +14,7 @@ use aranya_daemon_api::{
 };
 use aranya_util::Addr;
 use buggy::BugExt as _;
+use serde::{Deserialize, Serialize};
 use tarpc::context;
 use tokio::{fs, net::UnixStream};
 use tracing::{debug, error, info, instrument};
@@ -25,6 +26,7 @@ use crate::{
 };
 
 /// List of device IDs.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
 pub struct Devices {
     data: Vec<DeviceId>,
 }
@@ -42,6 +44,7 @@ impl Devices {
 }
 
 /// List of labels.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
 pub struct Labels {
     data: Vec<Label>,
 }
@@ -59,6 +62,7 @@ impl Labels {
 }
 
 /// Builds a [`Client`].
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct ClientBuilder<'a> {
     /// The UDS that the daemon is listening on.
     #[cfg(unix)]
@@ -70,10 +74,7 @@ pub struct ClientBuilder<'a> {
 impl ClientBuilder<'_> {
     /// Returns a default [`ClientBuilder`].
     pub fn new() -> Self {
-        Self {
-            uds_path: None,
-            aqc_addr: None,
-        }
+        Self::default()
     }
 
     /// Connects to the daemon.
@@ -96,12 +97,6 @@ impl ClientBuilder<'_> {
         Client::connect(sock, aqc_addr)
             .await
             .inspect_err(|err| error!(?err, "unable to connect to daemon"))
-    }
-}
-
-impl Default for ClientBuilder<'_> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -306,6 +301,7 @@ impl Client {
 /// - creating/assigning/deleting labels.
 /// - creating/deleting fast channels.
 /// - assigning network identifiers to devices.
+#[derive(Debug, Clone)]
 pub struct Team<'a> {
     client: &'a Client,
     team_id: TeamId,
@@ -507,7 +503,10 @@ impl Team<'_> {
     }
 }
 
-/// Facilitates fact database queries.
+/// Queries the Aranya fact database.
+///
+/// The fact database is updated when actions/effects are processed for a team.
+#[derive(Debug, Clone)]
 pub struct Queries<'a> {
     client: &'a Client,
     team_id: TeamId,

--- a/crates/aranya-client/src/config.rs
+++ b/crates/aranya-client/src/config.rs
@@ -33,7 +33,7 @@ impl From<SyncPeerConfig> for aranya_daemon_api::SyncPeerConfig {
 }
 
 /// Builder for a [`SyncPeerConfig`]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SyncPeerConfigBuilder {
     interval: Option<Duration>,
     sync_now: bool,

--- a/crates/aranya-client/src/config.rs
+++ b/crates/aranya-client/src/config.rs
@@ -33,6 +33,7 @@ impl From<SyncPeerConfig> for aranya_daemon_api::SyncPeerConfig {
 }
 
 /// Builder for a [`SyncPeerConfig`]
+#[derive(Debug, Clone)]
 pub struct SyncPeerConfigBuilder {
     interval: Option<Duration>,
     sync_now: bool,

--- a/crates/aranya-client/src/config/team.rs
+++ b/crates/aranya-client/src/config/team.rs
@@ -21,7 +21,7 @@ pub use quic_sync::{
 };
 
 /// Builder for [`CreateTeamConfig`].
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct CreateTeamConfigBuilder {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -45,7 +45,7 @@ impl CreateTeamConfigBuilder {
 }
 
 /// Builder for [`AddTeamConfig`].
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct AddTeamConfigBuilder {
     id: Option<TeamId>,
     quic_sync: Option<AddTeamQuicSyncConfig>,
@@ -84,7 +84,7 @@ impl AddTeamConfigBuilder {
 }
 
 /// Configuration for creating a new team.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CreateTeamConfig {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -105,7 +105,7 @@ impl From<CreateTeamConfig> for aranya_daemon_api::CreateTeamConfig {
 }
 
 /// Configuration for joining an existing team.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AddTeamConfig {
     id: TeamId,
     quic_sync: Option<AddTeamQuicSyncConfig>,

--- a/crates/aranya-client/src/config/team.rs
+++ b/crates/aranya-client/src/config/team.rs
@@ -21,7 +21,7 @@ pub use quic_sync::{
 };
 
 /// Builder for [`CreateTeamConfig`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct CreateTeamConfigBuilder {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -45,7 +45,7 @@ impl CreateTeamConfigBuilder {
 }
 
 /// Builder for [`AddTeamConfig`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct AddTeamConfigBuilder {
     id: Option<TeamId>,
     quic_sync: Option<AddTeamQuicSyncConfig>,

--- a/crates/aranya-client/src/config/team.rs
+++ b/crates/aranya-client/src/config/team.rs
@@ -84,7 +84,7 @@ impl AddTeamConfigBuilder {
 }
 
 /// Configuration for creating a new team.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct CreateTeamConfig {
     quic_sync: Option<CreateTeamQuicSyncConfig>,
 }
@@ -105,7 +105,7 @@ impl From<CreateTeamConfig> for aranya_daemon_api::CreateTeamConfig {
 }
 
 /// Configuration for joining an existing team.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AddTeamConfig {
     id: TeamId,
     quic_sync: Option<AddTeamQuicSyncConfig>,

--- a/crates/aranya-client/src/config/team/quic_sync.rs
+++ b/crates/aranya-client/src/config/team/quic_sync.rs
@@ -12,7 +12,7 @@ use tracing::error;
 use crate::{error::InvalidArg, ConfigError, Result};
 
 /// Configuration for creating a new team with QUIC synchronization.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CreateTeamQuicSyncConfig {
     mode: CreateSeedMode,
 }
@@ -25,7 +25,7 @@ impl CreateTeamQuicSyncConfig {
 }
 
 /// Configuration for adding members to an existing team with QUIC synchronization.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AddTeamQuicSyncConfig {
     mode: AddSeedMode,
 }
@@ -38,7 +38,7 @@ impl AddTeamQuicSyncConfig {
 }
 
 /// Builder for [`CreateTeamQuicSyncConfig`]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CreateTeamQuicSyncConfigBuilder {
     mode: CreateSeedMode,
 }
@@ -74,7 +74,7 @@ impl CreateTeamQuicSyncConfigBuilder {
 }
 
 /// Builder for [`AddTeamQuicSyncConfig`]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AddTeamQuicSyncConfigBuilder {
     mode: Option<AddSeedMode>,
 }

--- a/crates/aranya-client/src/config/team/quic_sync.rs
+++ b/crates/aranya-client/src/config/team/quic_sync.rs
@@ -12,7 +12,7 @@ use tracing::error;
 use crate::{error::InvalidArg, ConfigError, Result};
 
 /// Configuration for creating a new team with QUIC synchronization.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct CreateTeamQuicSyncConfig {
     mode: CreateSeedMode,
 }
@@ -25,7 +25,7 @@ impl CreateTeamQuicSyncConfig {
 }
 
 /// Configuration for adding members to an existing team with QUIC synchronization.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AddTeamQuicSyncConfig {
     mode: AddSeedMode,
 }

--- a/crates/aranya-client/src/error.rs
+++ b/crates/aranya-client/src/error.rs
@@ -65,7 +65,7 @@ pub(crate) fn aranya_error(err: api::Error) -> Error {
 }
 
 /// Possible errors that could happen when creating configuration info.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConfigError {
     /// An invalid argument was provided.
@@ -74,7 +74,7 @@ pub enum ConfigError {
 }
 
 /// An invalid argument.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[error("invalid argument `{arg}`: {reason}")]
 pub struct InvalidArg {
     arg: &'static str,

--- a/crates/aranya-client/src/error.rs
+++ b/crates/aranya-client/src/error.rs
@@ -65,7 +65,7 @@ pub(crate) fn aranya_error(err: api::Error) -> Error {
 }
 
 /// Possible errors that could happen when creating configuration info.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConfigError {
     /// An invalid argument was provided.
@@ -74,7 +74,7 @@ pub enum ConfigError {
 }
 
 /// An invalid argument.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 #[error("invalid argument `{arg}`: {reason}")]
 pub struct InvalidArg {
     arg: &'static str,

--- a/crates/aranya-daemon/Cargo.toml
+++ b/crates/aranya-daemon/Cargo.toml
@@ -42,6 +42,7 @@ bimap = "0.6"
 bytes = { workspace = true }
 ciborium = { workspace = true }
 clap = { workspace = true }
+derive-where = { workspace = true }
 futures-util = { workspace = true }
 postcard = { workspace = true }
 s2n-quic = { workspace = true }

--- a/crates/aranya-daemon/src/actions.rs
+++ b/crates/aranya-daemon/src/actions.rs
@@ -499,6 +499,7 @@ where
 /// An implementation of [`Actor`].
 /// Simplifies the process of calling an action on the Aranya graph.
 /// Enables more consistency and less repeated code for each action.
+#[derive(Debug)]
 pub struct ActorImpl<'a, EN, SP, CE, S> {
     client: &'a mut ClientState<EN, SP>,
     sink: &'a mut S,

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -20,6 +20,7 @@ use aranya_daemon_api::{
 use aranya_keygen::PublicKeys;
 use aranya_runtime::GraphId;
 use aranya_util::{task::scope, Addr};
+use derive_where::derive_where;
 use futures_util::{StreamExt, TryStreamExt};
 pub(crate) use quic_sync::Data as QSData;
 use tarpc::{
@@ -229,6 +230,7 @@ impl EffectHandler {
 ///
 /// This is separated out so we only have to clone one [`Arc`]
 /// (inside [`Api`]).
+#[derive_where(Debug)]
 struct ApiInner {
     client: Client,
     /// Local socket address of the API.
@@ -242,6 +244,7 @@ struct ApiInner {
     /// Keeps track of which graphs are invalid due to a finalization error.
     invalid: InvalidGraphs,
     aqc: Arc<Aqc<CE, KS>>,
+    #[derive_where(skip(Debug))]
     crypto: tokio::sync::Mutex<Crypto>,
     seed_id_dir: SeedDir,
     quic: Option<quic_sync::Data>,
@@ -263,18 +266,6 @@ impl ApiInner {
         let pk = self.pk.lock().expect("poisoned");
         let id = pk.ident_pk.id()?;
         Ok(id)
-    }
-}
-
-impl std::fmt::Debug for ApiInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Inner API Data")
-            .field("seed_id_dir", &self.seed_id_dir)
-            .field("client", &self.client)
-            .field("local_addr", &self.local_addr)
-            .field("pk", &self.pk)
-            .field("aqc", &self.aqc)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-daemon/src/aqc.rs
+++ b/crates/aranya-daemon/src/aqc.rs
@@ -1,4 +1,3 @@
-use core::fmt;
 use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Result;
@@ -12,6 +11,7 @@ use aranya_daemon_api::{
 use aranya_runtime::GraphId;
 use bimap::BiBTreeMap;
 use buggy::{bug, BugExt};
+use derive_where::derive_where;
 use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
@@ -25,12 +25,15 @@ use crate::{
 type PeerMap = BTreeMap<GraphId, Peers>;
 type Peers = BiBTreeMap<NetIdentifier, DeviceId>;
 
+#[derive_where(Debug)]
 pub(crate) struct Aqc<E, KS> {
     /// Our device ID.
     device_id: DeviceId,
     /// All the peers that we have channels with.
     peers: Arc<Mutex<PeerMap>>,
+    #[derive_where(skip(Debug))]
     handler: Mutex<Handler<AranyaStore<KS>>>,
+    #[derive_where(skip(Debug))]
     eng: Mutex<E>,
 }
 
@@ -264,14 +267,5 @@ where
             }
         })?;
         Ok(AqcPsks::Uni(psks))
-    }
-}
-
-impl<E, KS> fmt::Debug for Aqc<E, KS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Aqc")
-            .field("device_id", &self.device_id)
-            .field("peers", &self.peers)
-            .finish_non_exhaustive()
     }
 }

--- a/crates/aranya-daemon/src/config/toggle.rs
+++ b/crates/aranya-daemon/src/config/toggle.rs
@@ -38,6 +38,7 @@ mod imp {
 
     use super::Toggle;
 
+    #[derive(Debug, Clone)]
     pub struct True;
     impl<'de> Deserialize<'de> for True {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -57,7 +58,7 @@ mod imp {
         }
     }
 
-    #[derive(Default)]
+    #[derive(Debug, Clone, Default)]
     pub struct False;
     impl<'de> Deserialize<'de> for False {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -77,7 +78,7 @@ mod imp {
         }
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(untagged)]
     pub enum E<T> {
         Enabled {

--- a/crates/aranya-daemon/src/config/toggle.rs
+++ b/crates/aranya-daemon/src/config/toggle.rs
@@ -38,7 +38,7 @@ mod imp {
 
     use super::Toggle;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct True;
     impl<'de> Deserialize<'de> for True {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -58,7 +58,7 @@ mod imp {
         }
     }
 
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Default)]
     pub struct False;
     impl<'de> Deserialize<'de> for False {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -78,7 +78,7 @@ mod imp {
         }
     }
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize)]
     #[serde(untagged)]
     pub enum E<T> {
         Enabled {

--- a/crates/aranya-daemon/src/config/toggle.rs
+++ b/crates/aranya-daemon/src/config/toggle.rs
@@ -34,11 +34,12 @@ impl<T: Serialize> Serialize for Toggle<T> {
 }
 
 mod imp {
+    #![allow(missing_debug_implementations)]
+
     use serde::{de, ser, Deserialize, Serialize};
 
     use super::Toggle;
 
-    #[derive(Debug)]
     pub struct True;
     impl<'de> Deserialize<'de> for True {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -58,7 +59,7 @@ mod imp {
         }
     }
 
-    #[derive(Debug, Default)]
+    #[derive(Default)]
     pub struct False;
     impl<'de> Deserialize<'de> for False {
         fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -78,7 +79,7 @@ mod imp {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize)]
     #[serde(untagged)]
     pub enum E<T> {
         Enabled {

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Debug, io, path::Path, sync::Arc};
+use std::{collections::BTreeMap, io, path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
 use aranya_crypto::{

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io, path::Path, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug, io, path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
 use aranya_crypto::{
@@ -96,6 +96,8 @@ pub(crate) use invalid_graphs::InvalidGraphs;
 ///
 /// Dropping this will abort the daemon's tasks.
 #[clippy::has_significant_drop]
+#[derive(Debug)]
+
 pub struct DaemonHandle {
     set: JoinSet<()>,
 }
@@ -410,6 +412,15 @@ impl Daemon {
             }
         };
         bundle.public_keys(eng, store)
+    }
+}
+
+impl Debug for Daemon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Daemon")
+            .field("api", &self.api)
+            .field("span", &self.span)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -120,7 +120,7 @@ impl DaemonHandle {
 }
 
 /// The daemon itself.
-// TODO: #[derive(Debug)] once `LinearStorageProvider` and `DefaultEngine` implement it.
+#[derive(Debug)]
 pub struct Daemon {
     sync_server: SyncServer,
     syncer: Syncer<QuicSyncState>,
@@ -412,15 +412,6 @@ impl Daemon {
             }
         };
         bundle.public_keys(eng, store)
-    }
-}
-
-impl Debug for Daemon {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Daemon")
-            .field("api", &self.api)
-            .field("span", &self.span)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -97,7 +97,6 @@ pub(crate) use invalid_graphs::InvalidGraphs;
 /// Dropping this will abort the daemon's tasks.
 #[clippy::has_significant_drop]
 #[derive(Debug)]
-
 pub struct DaemonHandle {
     set: JoinSet<()>,
 }

--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -121,6 +121,7 @@ impl DaemonHandle {
 }
 
 /// The daemon itself.
+// TODO: #[derive(Debug)] once `LinearStorageProvider` and `DefaultEngine` implement it.
 pub struct Daemon {
     sync_server: SyncServer,
     syncer: Syncer<QuicSyncState>,

--- a/crates/aranya-daemon/src/sync/task.rs
+++ b/crates/aranya-daemon/src/sync/task.rs
@@ -118,6 +118,7 @@ type EffectSender = mpsc::Sender<(GraphId, Vec<EF>)>;
 /// Syncs with each peer after the specified interval.
 /// Uses a [`DelayQueue`] to obtain the next peer to sync with.
 /// Receives added/removed peers from [`SyncPeers`] via mpsc channels.
+#[derive(Debug)]
 pub struct Syncer<ST> {
     /// Aranya client to allow syncing the Aranya graph with another peer.
     pub client: Client,

--- a/crates/aranya-daemon/src/sync/task/quic.rs
+++ b/crates/aranya-daemon/src/sync/task/quic.rs
@@ -27,6 +27,7 @@ use aranya_util::{
 };
 use buggy::{bug, BugExt as _};
 use bytes::Bytes;
+use derive_where::derive_where;
 #[allow(deprecated)]
 use s2n_quic::provider::tls::rustls::rustls::{
     server::PresharedKeySelection, ClientConfig, ServerConfig,
@@ -330,7 +331,7 @@ impl Syncer<State> {
 
 /// The Aranya QUIC sync server.
 /// Used to listen for incoming `SyncRequests` and respond with `SyncResponse` when they are received.
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub struct Server<EN, SP> {
     /// Thread-safe Aranya client reference.
     aranya: AranyaClient<EN, SP>,

--- a/crates/aranya-daemon/src/sync/task/quic.rs
+++ b/crates/aranya-daemon/src/sync/task/quic.rs
@@ -86,6 +86,7 @@ pub enum Error {
 }
 
 /// QUIC syncer state used for sending sync requests and processing sync responses
+#[derive(Debug)]
 pub struct State {
     /// QUIC client to make sync requests to another peer's sync server and handle sync responses.
     client: QuicClient,
@@ -329,6 +330,7 @@ impl Syncer<State> {
 
 /// The Aranya QUIC sync server.
 /// Used to listen for incoming `SyncRequests` and respond with `SyncResponse` when they are received.
+#[derive(Debug)]
 pub struct Server<EN, SP> {
     /// Thread-safe Aranya client reference.
     aranya: AranyaClient<EN, SP>,

--- a/crates/aranya-util/src/task.rs
+++ b/crates/aranya-util/src/task.rs
@@ -69,10 +69,12 @@ where
 
 type Panic = Box<dyn Any + Send>;
 
+#[derive(Debug, Clone)]
 pub struct Scope {
     tracker: TaskTracker,
     tx: mpsc::Sender<Panic>,
 }
+
 impl Scope {
     fn new() -> (Self, mpsc::Receiver<Panic>) {
         let (tx, rx) = mpsc::channel(1);

--- a/crates/aranya-util/src/task.rs
+++ b/crates/aranya-util/src/task.rs
@@ -69,7 +69,7 @@ where
 
 type Panic = Box<dyn Any + Send>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Scope {
     tracker: TaskTracker,
     tx: mpsc::Sender<Panic>,


### PR DESCRIPTION
Eagerly implement `Debug` trait in the client's public Rust API:
https://rust-lang.github.io/api-guidelines/checklist.html

This PR adds whatever `Debug` traits can be easily added.
There are some cases where implementing traits would be more involved because the underlying types in `aranya-core` or a 3rd party lib would also need to implement those traits. This PR does not attempt to handle those cases.