### PR TITLE
doxygen: fix type links

### DIFF
--- a/crates/aranya-client-capi/docs/static/mainpage.md
+++ b/crates/aranya-client-capi/docs/static/mainpage.md
@@ -30,10 +30,14 @@ Before attempting to use this API, verify that you are using a matching version 
 Objects for creating an Aranya client and Aranya team:
 - `AranyaClient`
 - `AranyaClientConfig`
-- `AranyaTeamConfig`
-- `AranyaTeamConfigBuilder`
-- `AranyaQuicSyncConfig`
-- `AranyaQuicSyncConfigBuilder`
+- `AranyaCreateTeamConfig`
+- `AranyaCreateTeamConfigBuilder`
+- `AranyaCreateTeamQuicSyncConfig`
+- `AranyaCreateTeamQuicSyncConfigBuilder`
+- `AranyaAddTeamConfig`
+- `AranyaAddTeamConfigBuilder`
+- `AranyaAddTeamQuicSyncConfig`
+- `AranyaAddTeamQuicSyncConfigBuilder`
 - `AranyaSyncPeerConfig`
 - `AranyaSyncPeerConfigBuilder`
 


### PR DESCRIPTION
New types were added for `CreateTeam` and `AddTeam`. Fix the links to these types on the Doxygen landing page.