### PR TITLE
docs: crate READMEs use abs urls

### DIFF
--- a/crates/aranya-client/README.md
+++ b/crates/aranya-client/README.md
@@ -9,7 +9,7 @@
 [docs-badge]: https://docs.rs/aranya-client/badge.svg
 [docs-url]: https://docs.rs/aranya-client/latest/aranya_client/
 [license-badge]: https://img.shields.io/crates/l/aranya-client.svg
-[license-url]: ../../LICENSE.md
+[license-url]: https://github.com/aranya-project/aranya/blob/main/LICENSE.md
 
 ## Overview
 
@@ -36,14 +36,14 @@ The client provides the following functionality:
 - Send and receive encrypted data using Aranya Fast Channels. Fast Channels
   supports bidirectional encrypted data exchange over TCP transport.
 Note: The functionality noted 'as determined by the implemented policy' are
-defined in the [default policy](../aranya-daemon/src/policy.md). As such, these
+defined in the [default policy](https://github.com/aranya-project/aranya/blob/main/crates/aranya-daemon/src/policy.md). As such, these
 may differ depending on the policy implemented in your application.
 
 ## Examples
 
 An instance of the daemon must be running before the client can perform
 actions. Instructions for running an instance of the `daemon` binary can be
-found in the `aranya-daemon` [README](../aranya-daemon/README.md).
+found in the `aranya-daemon` [README](https://github.com/aranya-project/aranya/blob/main/crates/aranya-daemon/README.md).
 
 For a full demonstration of the client's capabilities, see the
 [walkthrough](https://aranya-project.github.io/aranya-docs/getting-started/walkthrough/).

--- a/crates/aranya-daemon/README.md
+++ b/crates/aranya-daemon/README.md
@@ -6,7 +6,7 @@
 [crates-badge]: https://img.shields.io/crates/v/aranya-daemon.svg
 [crates-url]: https://crates.io/crates/aranya-daemon
 [license-badge]: https://img.shields.io/crates/l/aranya-daemon.svg
-[license-url]: ../../LICENSE.md
+[license-url]: https://github.com/aranya-project/aranya/blob/main/LICENSE.md
 
 ## Overview
 
@@ -14,7 +14,7 @@ The Aranya Daemon is a long-running executable that is used to maintain
 the state of Aranya after adding commands to the graph or syncing commands from
 other peers by interacting directly with the
 [Aranya Core](https://github.com/aranya-project/aranya-core) library. See
-[here](../aranya-daemon-api/src/service.rs) for details on the Aranya
+[here](https://github.com/aranya-project/aranya/blob/main/crates/aranya-daemon-api/src/service.rs) for details on the Aranya
 functionality available through the daemon.
 
 The daemon's responsibilities include:
@@ -34,9 +34,9 @@ Note: The Aranya Daemon supports a single device.
 
 Create a config file for the daemon before running it. Refer to
 this documentation on the TOML config file parameters:
-[config](src/config.rs).
+[config](https://github.com/aranya-project/aranya/blob/main/crates/aranya-daemon/src/config.rs).
 
-An example daemon configuration file can be found [here](example.toml).
+An example daemon configuration file can be found [here](https://github.com/aranya-project/aranya/blob/main/crates/aranya-daemon/example.toml).
 
 ## Running the daemon
 

--- a/crates/aranya-keygen/README.md
+++ b/crates/aranya-keygen/README.md
@@ -9,7 +9,7 @@
 [docs-badge]: https://docs.rs/aranya-keygen/badge.svg
 [docs-url]: https://docs.rs/aranya-keygen/latest/aranya_keygen/
 [license-badge]: https://img.shields.io/crates/l/aranya-keygen.svg
-[license-url]: ../../LICENSE.md
+[license-url]: https://github.com/aranya-project/aranya/blob/main/LICENSE.md
 
 A utility crate for generating cryptographic key bundles for Aranya. This crate provides:
 


### PR DESCRIPTION
`docs.rs` requires absolute URLs to files in GitHub repos.