### PR TITLE
rustdoc: connect example

### DIFF
--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -137,6 +137,20 @@ impl Client {
     }
 
     /// Creates a client connection to the daemon.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use std::net::Ipv4Addr;
+    /// # use aranya_client::Client;
+    /// # #[tokio::main]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// let client = Client::builder()
+    ///     .daemon_uds_path("/var/run/aranya/uds.sock".as_ref())
+    ///     .aqc_server_addr(&(Ipv4Addr::UNSPECIFIED, 1234).into())
+    ///     .connect()
+    ///     .await?;
+    /// #    Ok(())
+    /// # }
     #[instrument(skip_all)]
     async fn connect(uds_path: &Path, aqc_addr: &Addr) -> Result<Self> {
         info!(path = ?uds_path, "connecting to daemon");

--- a/crates/aranya-util/src/task.rs
+++ b/crates/aranya-util/src/task.rs
@@ -40,7 +40,8 @@ use tracing::Instrument;
 ///         sleep(Duration::from_secs(1)).await;
 ///         println!("{msg}");
 ///     });
-/// }).await;
+/// })
+/// .await;
 /// # }
 /// ```
 pub async fn scope<F>(f: F)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 unstable_features = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
+format_code_in_doc_comments = true


### PR DESCRIPTION
Add a `rustdoc` example showing how the Aranya client can connect to the Aranya daemon.