### PR TITLE
Shared connection refactor

### DIFF
--- a/crates/aranya-daemon/src/sync/task/quic.rs
+++ b/crates/aranya-daemon/src/sync/task/quic.rs
@@ -499,7 +499,7 @@ where
             anyhow::Ok(())
         }
         .unwrap_or_else(move |err| {
-            error!(error = ?err, "TODO");
+            error!(error = ?err, "server unable to accept connection");
             handle.close(AppError::UNKNOWN);
         })
     }


### PR DESCRIPTION
I got drawn into doing some refactoring. I moved the server select arms into methods, and made the shared connection map not expose the lock as part of the API.