### PR TITLE
WIP: aqc: query daemon for valid channels

### DIFF
--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -601,4 +601,19 @@ impl Queries<'_> {
             .map_err(aranya_error)?;
         Ok(Labels { data })
     }
+
+    /// Returns a list of valid AQC channels.
+    pub async fn valid_aqc_channels(
+        &self,
+        chans: Vec<aranya_daemon_api::AqcChannelInfo>,
+    ) -> Result<Vec<bool>> {
+        let valid = self
+            .client
+            .daemon
+            .query_valid_aqc_channels(context::current(), chans)
+            .await
+            .map_err(IpcError::new)?
+            .map_err(aranya_error)?;
+        Ok(valid)
+    }
 }

--- a/crates/aranya-client/tests/aqc.rs
+++ b/crates/aranya-client/tests/aqc.rs
@@ -13,7 +13,6 @@ use buggy::BugExt;
 use bytes::{Bytes, BytesMut};
 use futures_util::{future::try_join, FutureExt};
 use tempfile::tempdir;
-use tracing::info;
 
 use crate::common::{sleep, DevicesCtx};
 
@@ -752,7 +751,6 @@ async fn test_aqc_query_valid_chans() -> Result<()> {
     let active = devices.membera.client.aqc().get_active_channels().await;
 
     // Query daemon to see which channels are valid.
-    info!("{:?}", active);
     let valid_channels = devices
         .membera
         .client
@@ -802,6 +800,8 @@ async fn test_aqc_query_valid_chans() -> Result<()> {
 
     // Verify AQC reports no active channels.
     let empty = devices.membera.client.aqc().get_active_channels().await;
+    assert!(empty.is_empty());
+    let empty = devices.memberb.client.aqc().get_active_channels().await;
     assert!(empty.is_empty());
 
     Ok(())

--- a/crates/aranya-daemon/src/actions.rs
+++ b/crates/aranya-daemon/src/actions.rs
@@ -494,6 +494,26 @@ where
         })
         .in_current_span()
     }
+
+    /// Query labels off-graph.
+    #[allow(clippy::type_complexity)]
+    #[instrument(skip(self))]
+    fn query_aqc_channel_valid_off_graph(
+        &self,
+        device_id: DeviceId,
+        peer_id: DeviceId,
+        label_id: LabelId,
+    ) -> impl Future<Output = Result<(Vec<Box<[u8]>>, Vec<Effect>)>> + Send {
+        self.session_action(move || VmAction {
+            name: ident!("query_aqc_channel_valid"),
+            args: Cow::Owned(vec![
+                Value::from(device_id),
+                Value::from(peer_id),
+                Value::from(label_id),
+            ]),
+        })
+        .in_current_span()
+    }
 }
 
 /// An implementation of [`Actor`].

--- a/crates/aranya-daemon/src/policy.rs
+++ b/crates/aranya-daemon/src/policy.rs
@@ -63,6 +63,7 @@ pub enum Effect {
     QueryDeviceKeyBundleResult(QueryDeviceKeyBundleResult),
     QueryAqcNetIdentifierResult(QueryAqcNetIdentifierResult),
     QueryAqcNetworkNamesOutput(QueryAqcNetworkNamesOutput),
+    QueriedBool(QueriedBool),
 }
 /// TeamCreated policy effect.
 #[effect]
@@ -259,6 +260,11 @@ pub struct QueryAqcNetworkNamesOutput {
     pub net_identifier: Text,
     pub device_id: Id,
 }
+/// QueriedBool policy effect.
+#[effect]
+pub struct QueriedBool {
+    pub result: bool,
+}
 /// Implements all supported policy actions.
 #[actions]
 pub trait ActorExt {
@@ -306,4 +312,10 @@ pub trait ActorExt {
     fn query_device_keybundle(&mut self, device_id: Id) -> Result<(), ClientError>;
     fn query_aqc_net_identifier(&mut self, device_id: Id) -> Result<(), ClientError>;
     fn query_aqc_network_names(&mut self) -> Result<(), ClientError>;
+    fn query_aqc_channel_valid(
+        &mut self,
+        device_id: Id,
+        peer_id: Id,
+        label_id: Id,
+    ) -> Result<(), ClientError>;
 }


### PR DESCRIPTION
Implement daemon query to determine which active AQC channels are still valid according to the policy.

TODO:
- [ ] Test with more channels

Out of scope for this PR:
- Have the Aranya client periodically run this query so it can delete invalid AQC channels
- Delete PSKs when an AQC channel is deleted