### PR TITLE
logging: remove error! from From impl

### DIFF
--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -9,7 +9,6 @@ use anyhow::Context as _;
 use aranya_capi_core::{opaque::Opaque, prelude::*, ErrorCode, InvalidArg};
 use aranya_client::aqc::{self, AqcPeerStream};
 use aranya_daemon_api::Text;
-use aranya_util::error::ReportExt as _;
 use bytes::Bytes;
 use tracing::error;
 

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -9,8 +9,9 @@ use anyhow::Context as _;
 use aranya_capi_core::{opaque::Opaque, prelude::*, ErrorCode, InvalidArg};
 use aranya_client::aqc::{self, AqcPeerStream};
 use aranya_daemon_api::Text;
+use aranya_util::error::ReportExt as _;
 use bytes::Bytes;
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::imp::{self, aqc::consume_bytes};
 
@@ -84,6 +85,7 @@ pub enum Error {
 
 impl From<&imp::Error> for Error {
     fn from(err: &imp::Error) -> Self {
+        debug!(error = %err.report(), "Aranya client C API error");
         match err {
             imp::Error::Bug(_) => Self::Bug,
             imp::Error::Timeout(_) => Self::Timeout,

--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -85,7 +85,6 @@ pub enum Error {
 
 impl From<&imp::Error> for Error {
     fn from(err: &imp::Error) -> Self {
-        error!(error = %err.report(), "Aranya client C API error");
         match err {
             imp::Error::Bug(_) => Self::Bug,
             imp::Error::Timeout(_) => Self::Timeout,


### PR DESCRIPTION
This is one location where excessive errors are logged by aranya. This line would log even during non-fatal errors like WouldBlock, causing logs to fill up quickly. 

Another solution could be to not log on WouldBlock and other non-fatal errors.