### PR TITLE
afc: C API Bindings

### DIFF
--- a/crates/aranya-client-capi/src/imp/afc.rs
+++ b/crates/aranya-client-capi/src/imp/afc.rs
@@ -1,0 +1,75 @@
+//! AFC-specific utilities for the Aranya Client C API.
+#![cfg(feature = "afc")]
+
+use aranya_capi_core::safe::{TypeId, Typed};
+use aranya_client::afc;
+
+/// All channel variants.
+#[derive(Debug)]
+pub enum AfcChannel {
+    Bidi(afc::BidiChannel),
+    Send(afc::SendChannel),
+    Receive(afc::ReceiveChannel),
+}
+
+impl Typed for AfcChannel {
+    const TYPE_ID: TypeId = TypeId::new(0xDC3130B2);
+}
+
+impl From<afc::Channel> for AfcChannel {
+    fn from(channel: afc::Channel) -> Self {
+        match channel {
+            afc::Channel::Bidi(c) => Self::Bidi(c),
+            afc::Channel::Send(c) => Self::Send(c),
+            afc::Channel::Recv(c) => Self::Receive(c),
+        }
+    }
+}
+
+impl From<afc::BidiChannel> for AfcChannel {
+    fn from(channel: afc::BidiChannel) -> Self {
+        Self::Bidi(channel)
+    }
+}
+
+impl From<afc::SendChannel> for AfcChannel {
+    fn from(channel: afc::SendChannel) -> Self {
+        Self::Send(channel)
+    }
+}
+
+impl From<afc::ReceiveChannel> for AfcChannel {
+    fn from(channel: afc::ReceiveChannel) -> Self {
+        Self::Receive(channel)
+    }
+}
+
+/// A control message, for creating the other end of a channel.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct AfcCtrlMsg(pub(crate) afc::CtrlMsg);
+
+impl Typed for AfcCtrlMsg {
+    const TYPE_ID: TypeId = TypeId::new(0xB421D1CE);
+}
+
+impl From<afc::CtrlMsg> for AfcCtrlMsg {
+    fn from(msg: afc::CtrlMsg) -> Self {
+        Self(msg)
+    }
+}
+
+/// A sequence number, for reordering messages.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct AfcSeq(afc::Seq);
+
+impl Typed for AfcSeq {
+    const TYPE_ID: TypeId = TypeId::new(0xC4DCE0C0);
+}
+
+impl From<afc::Seq> for AfcSeq {
+    fn from(seq: afc::Seq) -> Self {
+        Self(seq)
+    }
+}

--- a/crates/aranya-client-capi/src/imp/error.rs
+++ b/crates/aranya-client-capi/src/imp/error.rs
@@ -4,6 +4,8 @@ use aranya_capi_core::{
     safe::{TypeId, Typed},
     write_c_str, ExtendedError, InvalidArg, WriteCStrError,
 };
+#[cfg(feature = "afc")]
+use aranya_client::afc;
 #[cfg(feature = "aqc")]
 use aranya_client::{aqc::TryReceiveError, error::AqcError};
 use buggy::Bug;
@@ -33,6 +35,10 @@ pub enum Error {
     #[error("connection was unexpectedly closed")]
     Closed,
 
+    #[cfg(feature = "afc")]
+    #[error("wrong channel type provided")]
+    WrongChannelType,
+
     #[error(transparent)]
     Utf8(#[from] core::str::Utf8Error),
 
@@ -50,6 +56,13 @@ pub enum Error {
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(feature = "afc")]
+impl From<afc::Error> for Error {
+    fn from(value: afc::Error) -> Self {
+        Self::Client(aranya_client::Error::Afc(value))
+    }
 }
 
 #[cfg(feature = "aqc")]

--- a/crates/aranya-client-capi/src/imp/mod.rs
+++ b/crates/aranya-client-capi/src/imp/mod.rs
@@ -1,8 +1,11 @@
+pub mod afc;
 pub mod aqc;
 pub mod client;
 pub mod config;
 pub mod error;
 
+#[cfg(feature = "afc")]
+pub use afc::*;
 #[cfg(feature = "aqc")]
 pub use aqc::*;
 pub use client::*;


### PR DESCRIPTION
- [x] create_channel()
- [x] recv_ctrl()
- [x] get_channel_type()
- [x] open()
- [x] seal()
- [ ] `seq_cmp(seq1, seq2) -> int` to compare `Seq`
- [x] delete_channel()
- [x] Feature flags for afc, preview
- [x] label_id()
- [ ] Update C example with AFC example
- [ ] unlink afc shm files in example.c https://github.com/aranya-project/aranya/issues/494