### PR TITLE
Add aqc feature to metrics crate

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -313,7 +313,7 @@ script = '''
 #!/usr/bin/env bash
 set -e
 cargo build --bin aranya-daemon --release --features=experimental,aqc
-cargo build --bin aranya-metrics --release
+cargo build --bin aranya-metrics --release --features=aqc
 CONFIG_PATH=$(pwd)/crates/aranya-metrics/example-metrics.toml $(pwd)/target/release/aranya-metrics $(pwd)/target/release/aranya-daemon
 '''
 

--- a/crates/aranya-metrics/Cargo.toml
+++ b/crates/aranya-metrics/Cargo.toml
@@ -15,13 +15,15 @@ workspace = true
 [features]
 default = []
 
+aqc = ["aranya-client/aqc", "aranya-client/experimental"]
+
 datadog = ["dep:metrics-exporter-dogstatsd"]
 prometheus = ["dep:metrics-exporter-prometheus"]
 tcp = ["dep:metrics-exporter-tcp"]
 
 
 [dependencies]
-aranya-client = { workspace = true, features = ["aqc", "experimental"] }
+aranya-client = { workspace = true }
 aranya-daemon-api = { workspace = true }
 aranya-util = { workspace = true }
 buggy = { workspace = true }
@@ -52,5 +54,6 @@ metrics-exporter-tcp = { version = "0.11", optional = true }
 [[bin]]
 name = "aranya-metrics"
 path = "src/main.rs"
+required-features = ["aqc"]
 test = false
 bench = false

--- a/crates/aranya-metrics/prometheus.bash
+++ b/crates/aranya-metrics/prometheus.bash
@@ -13,8 +13,8 @@ if ! command -v pushgateway >/dev/null 2>&1; then
 fi
 
 echo "Building our binaries..."
-cargo build --bin aranya-daemon --release
-cargo build --bin aranya-metrics --release --features prometheus
+cargo build --bin aranya-daemon --release --features aqc,experimental
+cargo build --bin aranya-metrics --release --features prometheus,aqc
 
 # We assume that if they installed prometheus, it's already running in the background.
 echo "Starting pushgateway..."


### PR DESCRIPTION
This is a minimal change to make bare `cargo check` on the workspace pass again. 