### PR TITLE
chore: use IDs by value

### DIFF
--- a/crates/aranya-client/src/client.rs
+++ b/crates/aranya-client/src/client.rs
@@ -153,8 +153,8 @@ pub struct Devices {
 
 impl Devices {
     /// Return iterator for list of devices.
-    pub fn iter(&self) -> impl Iterator<Item = &DeviceId> {
-        self.data.iter()
+    pub fn iter(&self) -> impl Iterator<Item = DeviceId> + use<'_> {
+        self.data.iter().copied()
     }
 
     #[doc(hidden)]

--- a/crates/aranya-daemon/src/actions.rs
+++ b/crates/aranya-daemon/src/actions.rs
@@ -56,20 +56,20 @@ where
 
     /// Returns an implementation of [`Actions`] for a particular
     /// storage.
-    #[instrument(skip_all, fields(id = %id))]
-    pub fn actions(&self, id: &GraphId) -> impl Actions<EN, SP, CE> {
+    #[instrument(skip_all, fields(%graph_id))]
+    pub fn actions(&self, graph_id: GraphId) -> impl Actions<EN, SP, CE> {
         ActionsImpl {
             aranya: Arc::clone(&self.aranya),
-            graph_id: *id,
+            graph_id,
             _eng: PhantomData,
         }
     }
 
     /// Create new ephemeral Session.
     /// Once the Session has been created, call `session_receive` to add an ephemeral command to the Session.
-    #[instrument(skip_all, fields(id = %id))]
-    pub(crate) async fn session_new(&self, id: &GraphId) -> Result<Session<SP, EN>> {
-        let session = self.aranya.lock().await.session(*id)?;
+    #[instrument(skip_all, fields(%graph_id))]
+    pub(crate) async fn session_new(&self, graph_id: GraphId) -> Result<Session<SP, EN>> {
+        let session = self.aranya.lock().await.session(graph_id)?;
         Ok(session)
     }
 

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -452,7 +452,7 @@ impl DaemonApi for Api {
             self.remove_team_quic_sync(team, data)?;
         }
 
-        self.seed_id_dir.remove(&team).await?;
+        self.seed_id_dir.remove(team).await?;
 
         self.client
             .aranya
@@ -517,8 +517,8 @@ impl DaemonApi for Api {
         let (seed, enc_sk) = {
             let crypto = &mut *self.crypto.lock().await;
             let seed = {
-                let seed_id = self.seed_id_dir.get(&team).await?;
-                qs::PskSeed::load(&mut crypto.engine, &crypto.local_store, &seed_id)?
+                let seed_id = self.seed_id_dir.get(team).await?;
+                qs::PskSeed::load(&mut crypto.engine, &crypto.local_store, seed_id)?
                     .context("no seed in dir")?
             };
             let enc_sk: EncryptionKey<CS> = crypto
@@ -551,7 +551,7 @@ impl DaemonApi for Api {
         self.check_team_valid(team).await?;
 
         self.client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .add_member(keys.into())
             .await
             .context("unable to add device to team")?;
@@ -568,7 +568,7 @@ impl DaemonApi for Api {
         self.check_team_valid(team).await?;
 
         self.client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .remove_member(device.into_id().into())
             .await
             .context("unable to remove device from team")?;
@@ -586,7 +586,7 @@ impl DaemonApi for Api {
         self.check_team_valid(team).await?;
 
         self.client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .assign_role(device.into_id().into(), role.into())
             .await
             .context("unable to assign role")?;
@@ -604,7 +604,7 @@ impl DaemonApi for Api {
         self.check_team_valid(team).await?;
 
         self.client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .revoke_role(device.into_id().into(), role.into())
             .await
             .context("unable to revoke device role")?;
@@ -628,7 +628,7 @@ impl DaemonApi for Api {
 
         let (ctrl, effects) = self
             .client
-            .actions(&graph)
+            .actions(graph)
             .create_afc_uni_channel_off_graph(peer_id.into_id().into(), label.into_id().into())
             .await?;
 
@@ -669,7 +669,7 @@ impl DaemonApi for Api {
         self.check_team_valid(team).await?;
 
         let graph = GraphId::from(team.into_id());
-        let mut session = self.client.session_new(&graph).await?;
+        let mut session = self.client.session_new(graph).await?;
 
         let effects = self.client.session_receive(&mut session, &ctrl).await?;
 
@@ -696,7 +696,7 @@ impl DaemonApi for Api {
 
         let effects = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .create_label(label_name)
             .await
             .context("unable to create label")?;
@@ -719,7 +719,7 @@ impl DaemonApi for Api {
 
         let effects = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .delete_label(label_id.into_id().into())
             .await
             .context("unable to delete label")?;
@@ -744,7 +744,7 @@ impl DaemonApi for Api {
 
         let effects = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .assign_label(
                 device.into_id().into(),
                 label_id.into_id().into(),
@@ -772,7 +772,7 @@ impl DaemonApi for Api {
 
         let effects = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .revoke_label(device.into_id().into(), label_id.into_id().into())
             .await
             .context("unable to revoke label")?;
@@ -794,7 +794,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_devices_on_team_off_graph()
             .await
             .context("unable to query devices on team")?;
@@ -818,7 +818,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_device_role_off_graph(device.into_id().into())
             .await
             .context("unable to query device role")?;
@@ -842,7 +842,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_device_keybundle_off_graph(device.into_id().into())
             .await
             .context("unable to query device keybundle")?;
@@ -867,7 +867,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_label_assignments_off_graph(device.into_id().into())
             .await
             .context("unable to query device label assignments")?;
@@ -896,7 +896,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_label_exists_off_graph(label_id.into_id().into())
             .await
             .context("unable to query label")?;
@@ -920,7 +920,7 @@ impl DaemonApi for Api {
 
         let (_ctrl, effects) = self
             .client
-            .actions(&team.into_id().into())
+            .actions(team.into_id().into())
             .query_labels_off_graph()
             .await
             .context("unable to query labels")?;
@@ -955,7 +955,7 @@ impl Api {
 
         if let Err(e) = self
             .seed_id_dir
-            .append(&team, &id)
+            .append(team, id)
             .await
             .context("could not write seed id to file")
         {

--- a/crates/aranya-daemon/src/sync/task/quic/psk.rs
+++ b/crates/aranya-daemon/src/sync/task/quic/psk.rs
@@ -44,10 +44,10 @@ impl PskSeed {
     pub(crate) fn load(
         eng: &mut CE,
         store: &LocalStore<KS>,
-        id: &PskSeedId,
+        id: PskSeedId,
     ) -> Result<Option<Self>> {
         store
-            .get_key(eng, *id)
+            .get_key(eng, id)
             .map(|r| r.map(Self))
             .map_err(Into::into)
     }

--- a/crates/aranya-daemon/src/test.rs
+++ b/crates/aranya-daemon/src/test.rs
@@ -138,7 +138,7 @@ impl TestDevice {
         LinearStorageProvider<FileManager>,
         DefaultEngine<Rng>,
     > {
-        self.syncer.client().actions(&self.graph_id)
+        self.syncer.client().actions(self.graph_id)
     }
 }
 

--- a/crates/aranya-daemon/src/util.rs
+++ b/crates/aranya-daemon/src/util.rs
@@ -25,11 +25,11 @@ impl SeedDir {
         Ok(Self(p))
     }
 
-    pub(crate) async fn get(&self, team_id: &TeamId) -> Result<PskSeedId> {
+    pub(crate) async fn get(&self, team_id: TeamId) -> Result<PskSeedId> {
         Self::read_id(self.0.join(team_id.to_string())).await
     }
 
-    pub(crate) async fn append(&self, team_id: &TeamId, seed_id: &PskSeedId) -> Result<()> {
+    pub(crate) async fn append(&self, team_id: TeamId, seed_id: PskSeedId) -> Result<()> {
         let file_name = self.0.join(team_id.to_string());
 
         // fail if a file with the same name already exists
@@ -41,7 +41,7 @@ impl SeedDir {
         Ok(())
     }
 
-    pub(crate) async fn remove(&self, team_id: &TeamId) -> Result<()> {
+    pub(crate) async fn remove(&self, team_id: TeamId) -> Result<()> {
         let file_name = self.0.join(team_id.to_string());
         remove_file(file_name)
             .await
@@ -85,7 +85,7 @@ pub(crate) async fn load_team_psk_pairs(
     let mut out = Vec::new();
 
     for (team_id, seed_id) in pairs {
-        let Some(seed) = qs::PskSeed::load(eng, store, &seed_id)? else {
+        let Some(seed) = qs::PskSeed::load(eng, store, seed_id)? else {
             continue;
         };
 
@@ -131,7 +131,7 @@ mod tests {
             }
 
             seed_dir
-                .append(&team_id, &seed_id)
+                .append(team_id, seed_id)
                 .await
                 .context("could not append")?;
 
@@ -162,11 +162,11 @@ mod tests {
             let seed_id = PskSeedId::random(&mut Rng);
 
             seed_dir
-                .append(&team_id, &seed_id)
+                .append(team_id, seed_id)
                 .await
                 .context("could not append")?;
 
-            assert!(seed_dir.remove(&team_id).await.is_ok())
+            assert!(seed_dir.remove(team_id).await.is_ok())
         }
 
         Ok(())

--- a/examples/rust/aranya-example-multi-node/src/lib.rs
+++ b/examples/rust/aranya-example-multi-node/src/lib.rs
@@ -16,7 +16,7 @@ pub async fn get_member_peer(
     let team = client.team(team);
     let queries = team.queries();
     let devices = queries.devices_on_team().await?;
-    for &device in devices.iter() {
+    for device in devices.iter() {
         if device.__id == this_device.__id {
             continue;
         }


### PR DESCRIPTION
Use IDs by value for consistency and ease of use. We made the same choice in aranya-core a while ago.

(The C API still takes them by reference since it affects the ABI)