### PR TITLE
custom-roles: fix client/server address

### DIFF
--- a/crates/aranya-daemon/src/daemon.rs
+++ b/crates/aranya-daemon/src/daemon.rs
@@ -341,6 +341,7 @@ impl Daemon {
             invalid_graphs,
             Arc::clone(&psk_store),
             client_addr,
+            server_addr,
             Arc::clone(&caches),
         )?;
 

--- a/crates/aranya-daemon/src/sync/task.rs
+++ b/crates/aranya-daemon/src/sync/task.rs
@@ -172,8 +172,8 @@ pub struct Syncer<ST> {
     invalid: InvalidGraphs,
     /// Additional state used by the syncer.
     state: ST,
-    /// Sync server address.
-    client_addr: Addr,
+    /// Sync server address. Peers will make incoming connections to us on this address.
+    server_addr: Addr,
     /// Thread-safe reference to an [`Addr`]->[`PeerCache`] map.
     /// Lock must be acquired after [`Self::client`]
     caches: PeerCacheMap,

--- a/crates/aranya-daemon/src/sync/task/quic.rs
+++ b/crates/aranya-daemon/src/sync/task/quic.rs
@@ -136,7 +136,7 @@ impl SyncState for State {
         // TODO: spawn a task for send/recv?
         let (mut recv, mut send) = stream.split();
 
-        let mut sync_requester = SyncRequester::new(id, &mut Rng, syncer.client_addr);
+        let mut sync_requester = SyncRequester::new(id, &mut Rng, syncer.server_addr);
 
         // send sync request.
         syncer
@@ -196,6 +196,7 @@ impl Syncer<State> {
         invalid: InvalidGraphs,
         psk_store: Arc<PskStore>,
         client_addr: Addr,
+        server_addr: Addr,
         caches: PeerCacheMap,
     ) -> SyncResult<(
         Self,
@@ -218,7 +219,7 @@ impl Syncer<State> {
                 send_effects,
                 invalid,
                 state,
-                client_addr,
+                server_addr,
                 caches,
             },
             peers,

--- a/crates/aranya-daemon/src/test.rs
+++ b/crates/aranya-daemon/src/test.rs
@@ -243,7 +243,7 @@ impl TestCtx {
 
             let aranya = Arc::new(Mutex::new(graph));
             let client = TestClient::new(Arc::clone(&aranya));
-            let local_addr = Addr::from((Ipv4Addr::LOCALHOST, 0));
+            let any_local_addr = Addr::from((Ipv4Addr::LOCALHOST, 0));
             let psk_store = PskStore::new([]);
             let psk_store = Arc::new(psk_store);
 
@@ -254,7 +254,8 @@ impl TestCtx {
                     send_effects,
                     InvalidGraphs::default(),
                     psk_store.clone(),
-                    Addr::from((Ipv4Addr::LOCALHOST, 0)),
+                    any_local_addr,
+                    any_local_addr,
                     caches.clone(),
                 )?;
 
@@ -263,7 +264,7 @@ impl TestCtx {
 
             let server: TestServer = TestServer::new(
                 client.clone(),
-                &local_addr,
+                &any_local_addr,
                 psk_store.clone(),
                 conn_map,
                 conn_rx,


### PR DESCRIPTION
The address passed into `SyncRequester::new` should be the server since the peer needs to reach out to that address to make connections in the case of push or hello sync.