### PR TITLE
release patch: don't publish examples to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-example"
-version = "4.0.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "aranya-client",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-example-multi-node"
-version = "4.0.0"
+version = "0.0.0"
 dependencies = [
  "age",
  "anyhow",

--- a/examples/rust/aranya-example-multi-node/Cargo.toml
+++ b/examples/rust/aranya-example-multi-node/Cargo.toml
@@ -2,7 +2,6 @@
 name = "aranya-example-multi-node"
 description = "Example of how to run each Aranya device on a different machine in a network"
 publish = false
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/examples/rust/aranya-example/Cargo.toml
+++ b/examples/rust/aranya-example/Cargo.toml
@@ -2,7 +2,6 @@
 name = "aranya-example"
 description = "Example Rust program using the Aranya client library"
 publish = false
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -47,9 +47,11 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.aranya-example]
+audit-as-crates-io = false
 criteria = "safe-to-run"
 
 [policy.aranya-example-multi-node]
+audit-as-crates-io = false
 criteria = "safe-to-run"
 
 [policy.aranya-keygen]


### PR DESCRIPTION
`cargo vet check` failed after releasing 4.0.0:
https://github.com/aranya-project/aranya/actions/runs/19378549728/job/55451916422

This occurred because the aranya example crates were inadvertently published.
Set `publish = false` to no longer publish the aranya example crates.

We've requested that DevOps yank the crates from crates.io.