### PR TITLE
ci: fix cargo deny errors/warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,8 @@ ignore = [
     # The `paste` crate is unmaintained. There isn't anything we
     # can do here.
     "RUSTSEC-2024-0436",
+    # The `rustls-pemfile` crate is unmaintained. We're not using certs anyways.
+    "RUSTSEC-2025-0134",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -144,9 +146,6 @@ exceptions = [
     { allow = ["AGPL-3.0"], crate = "aranya-daemon-api" },
     { allow = ["AGPL-3.0"], crate = "aranya-keygen" },
     { allow = ["AGPL-3.0"], crate = "aranya-util" },
-
-    { allow = ["AGPL-3.0"], crate = "aranya-example" },
-    { allow = ["AGPL-3.0"], crate = "aranya-example-multi-node" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -37,8 +37,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.aranya-afc-util]]
-version = "0.16.0"
-when = "2025-11-05"
+version = "0.17.0"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -67,26 +67,26 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-crypto-ffi]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-device-ffi]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-envelope-ffi]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-fast-channels]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.16.0"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -97,8 +97,8 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-idam-ffi]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -127,8 +127,8 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-perspective-ffi]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -139,8 +139,8 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-compiler]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.16.0"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -151,14 +151,14 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-ifgen]]
-version = "0.16.0"
-when = "2025-11-05"
+version = "0.16.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-ifgen-build]]
-version = "0.9.0"
-when = "2025-11-05"
+version = "0.10.0"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
@@ -193,14 +193,14 @@ user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-policy-vm]]
-version = "0.15.0"
-when = "2025-11-05"
+version = "0.15.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 
 [[publisher.aranya-runtime]]
-version = "0.16.0"
-when = "2025-11-05"
+version = "0.16.1"
+when = "2025-11-13"
 user-id = 293722
 user-login = "aranya-project-bot"
 


### PR DESCRIPTION
```
warning: 3 allowed warnings found
[cargo-make] INFO - Execute Command: "cargo" "deny" "check"
warning[license-exception-not-encountered]: license exception was not encountered
    ┌─ /Users/gknopf/scm/aranya/deny.toml:148:38
    │
148 │     { allow = ["AGPL-3.0"], crate = "aranya-example" },
    │                                      ━━━━━━━━━━━━━━ unmatched license exception

warning[license-exception-not-encountered]: license exception was not encountered
    ┌─ /Users/gknopf/scm/aranya/deny.toml:149:38
    │
149 │     { allow = ["AGPL-3.0"], crate = "aranya-example-multi-node" },
    │                                      ━━━━━━━━━━━━━━━━━━━━━━━━━ unmatched license exception

error[unmaintained]: rustls-pemfile is unmaintained
    ┌─ /Users/gknopf/scm/aranya/Cargo.lock:301:1
    │
301 │ rustls-pemfile 2.2.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
```

`rustls-pemfile` is no longer maintained. This can be ignored since we don't use certs and there isn't a safe upgrade available.
The license exceptions can be removed since they are causing a warning. I suspect it's because we aren't publishing the example crates.