### PR TITLE
fix: replace panic with error handling for empty hello response

### DIFF
--- a/crates/aranya-daemon/src/sync/mod.rs
+++ b/crates/aranya-daemon/src/sync/mod.rs
@@ -6,7 +6,7 @@ use error::SyncError;
 /// Possible sync related errors
 pub type Result<T> = core::result::Result<T, SyncError>;
 
-mod error {
+pub(crate) mod error {
     use std::convert::Infallible;
 
     use thiserror::Error;
@@ -24,6 +24,9 @@ mod error {
         SendSyncRequest(Box<SyncError>),
         #[error("Could not receive sync response: {0}")]
         ReceiveSyncResponse(Box<SyncError>),
+        /// Peer sent an empty response
+        #[error("peer sent empty response")]
+        EmptyResponse,
         #[error(transparent)]
         Bug(#[from] buggy::Bug),
         #[error(transparent)]

--- a/crates/aranya-daemon/src/sync/task/hello.rs
+++ b/crates/aranya-daemon/src/sync/task/hello.rs
@@ -20,6 +20,7 @@ use tracing::{debug, instrument, trace, warn};
 use crate::{
     aranya::ClientWithState,
     sync::{
+        error::SyncError,
         task::{
             quic::{Error, Server, State},
             PeerCacheKey, SyncPeers, Syncer,
@@ -184,7 +185,9 @@ impl Syncer<State> {
         recv.read_to_end(&mut response_buf)
             .await
             .with_context(|| format!("failed to read hello {} response", operation_name))?;
-        assert!(!response_buf.is_empty());
+        if response_buf.is_empty() {
+            return Err(SyncError::EmptyResponse);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Replace `assert!(!response_buf.is_empty())` in `send_hello_request()` with proper error handling using a new `Error::EmptyResponse` error variant.

This prevents a potential DoS vulnerability where a malicious peer could crash the daemon by sending an empty response to hello requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)