### PR TITLE
sync: introduce jitter on sync requests

### DIFF
--- a/crates/aranya-daemon/src/sync/task.rs
+++ b/crates/aranya-daemon/src/sync/task.rs
@@ -28,9 +28,7 @@
 //!
 //! See the [`hello`] module for implementation details.
 
-#[cfg(feature = "preview")]
-use std::time::Duration;
-use std::{collections::HashMap, future::Future};
+use std::{collections::HashMap, future::Future, time::Duration};
 
 use anyhow::Context;
 use aranya_crypto::{dangerous::spideroak_crypto::csprng::rand::RngCore, Rng};


### PR DESCRIPTION
Introduce a random jitter on sync requests so the next request falls somewhere on the interval of `[interval/2, interval*3/2]`.