### PR TITLE
syncer: add jitter before sending sync hello notifications

### DIFF
--- a/crates/aranya-daemon/src/sync/task/hello.rs
+++ b/crates/aranya-daemon/src/sync/task/hello.rs
@@ -318,6 +318,11 @@ impl Syncer<State> {
             // This helps to prevent self DoS via a bunch of subsequent sync requests at the same time from various peers.
             let rand = Rng.next_u32();
             let jitter = graph_change_delay.mul_f64(f64::from(rand) / f64::from(u32::MAX)) / 10;
+            trace!(
+                ?jitter,
+                ?peer,
+                "applying jitter before sending hello notification"
+            );
             sleep(jitter).await;
 
             let (mut recv, mut send) = stream.split();


### PR DESCRIPTION
Introduces a random jitter on the interval of `[0, graph_change_delay/10]` before sending each hello notification.

Jitter does not need to be introduced before connection/stream establishment because the goal is to spread out the returned sync requests after hello notifications are sent out.

TODO:
- Should the jitter be configurable in the sync config?