### PR TITLE
chore: release 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-certgen"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "clap",
  "rcgen",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-client"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "aranya-client",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "aranya-afc-util",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-daemon-api"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-keygen"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-util"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "aranya-internal-s2n-quic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 
 [workspace.package]
-version = "4.2.0"
+version = "5.0.0"
 authors = ["SpiderOak, Inc."]
 edition = "2021"
 license = "AGPL-3.0-only"
@@ -58,11 +58,11 @@ aranya-runtime = { version = "0.19.0", features = ["std", "libc"] }
 buggy = { version = "0.1.0" }
 spideroak-base58 = { version = "0.2.0" }
 
-aranya-client = { version = "4.2.0", path = "crates/aranya-client", default-features = false }
-aranya-daemon = { version = "4.2.0", path = "crates/aranya-daemon", default-features = false }
-aranya-daemon-api = { version = "4.2.0", path = "crates/aranya-daemon-api", default-features = false }
-aranya-keygen = { version = "4.2.0", path = "crates/aranya-keygen", default-features = false }
-aranya-util = { version = "4.2.0", path = "crates/aranya-util", default-features = false }
+aranya-client = { version = "5.0.0", path = "crates/aranya-client", default-features = false }
+aranya-daemon = { version = "5.0.0", path = "crates/aranya-daemon", default-features = false }
+aranya-daemon-api = { version = "5.0.0", path = "crates/aranya-daemon-api", default-features = false }
+aranya-keygen = { version = "5.0.0", path = "crates/aranya-keygen", default-features = false }
+aranya-util = { version = "5.0.0", path = "crates/aranya-util", default-features = false }
 
 # External dependencies
 anyhow = { version = "1.0.86" }


### PR DESCRIPTION
Patch release for https://rustsec.org/advisories/RUSTSEC-2026-0007

There are breaking changes that require more than a patch version bump.