### PR TITLE
aranya-client: make AFC `ChannelId` an aranya-id

### DIFF
--- a/crates/aranya-client-capi/src/api/defs.rs
+++ b/crates/aranya-client-capi/src/api/defs.rs
@@ -632,7 +632,7 @@ impl From<afc::ChannelId> for AfcChannelId {
     fn from(value: afc::ChannelId) -> Self {
         Self {
             id: Id {
-                bytes: value.__id.into(),
+                bytes: value.into(),
             },
         }
     }
@@ -641,9 +641,7 @@ impl From<afc::ChannelId> for AfcChannelId {
 #[cfg(feature = "afc")]
 impl From<&AfcChannelId> for afc::ChannelId {
     fn from(value: &AfcChannelId) -> Self {
-        Self {
-            __id: aranya_daemon_api::AfcChannelId::from_bytes(value.id.bytes),
-        }
+        value.id.bytes.into()
     }
 }
 

--- a/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
+++ b/crates/aranya-client-capi/src/imp/config/team/quic_sync.rs
@@ -79,7 +79,6 @@ impl CreateTeamQuicSyncConfigBuilder {
     /// Sets the PSK seed mode.
     ///
     /// This method will be removed soon since certificates will be used instead of PSKs in the future.
-    #[doc(hidden)]
     pub fn mode(&mut self, mode: CreateSeedMode) {
         self.mode = mode;
     }
@@ -126,7 +125,6 @@ impl AddTeamQuicSyncConfigBuilder {
     /// Sets the PSK seed mode.
     ///
     /// This method will be removed soon since certificates will be used instead of PSKs in the future.
-    #[doc(hidden)]
     pub fn mode(&mut self, mode: AddSeedMode) {
         self.mode = Some(mode);
     }

--- a/crates/aranya-client/src/client/device.rs
+++ b/crates/aranya-client/src/client/device.rs
@@ -21,13 +21,11 @@ pub struct PublicKeyBundle(api::PublicKeyBundle);
 pub type KeyBundle = PublicKeyBundle;
 
 impl PublicKeyBundle {
-    #[doc(hidden)]
-    pub fn from_api(api: api::PublicKeyBundle) -> Self {
+    pub(crate) fn from_api(api: api::PublicKeyBundle) -> Self {
         Self(api)
     }
 
-    #[doc(hidden)]
-    pub fn into_api(self) -> api::PublicKeyBundle {
+    pub(crate) fn into_api(self) -> api::PublicKeyBundle {
         self.0
     }
 

--- a/crates/aranya-client/src/client/label.rs
+++ b/crates/aranya-client/src/client/label.rs
@@ -53,11 +53,6 @@ impl Labels {
     pub fn __data(&self) -> &[Label] {
         &self.labels
     }
-
-    #[doc(hidden)]
-    pub fn __into_data(self) -> Box<[Label]> {
-        self.labels
-    }
 }
 
 impl IntoIterator for Labels {


### PR DESCRIPTION
Missed this one in #682.

Also cleans up some unused `doc(hidden)`.