### PR TITLE
fix: add generation counter tests and fix RevokeLabelFromDevice

### DIFF
--- a/crates/aranya-client/Cargo.toml
+++ b/crates/aranya-client/Cargo.toml
@@ -53,7 +53,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 aranya-client = { path = ".", features = ["preview"] }
-aranya-daemon = { path = "../aranya-daemon", features = ["experimental", "preview"] }
+aranya-daemon = { path = "../aranya-daemon", features = ["experimental", "preview", "test-utils"] }
 spideroak-base58 = { workspace = true }
 
 backon = { workspace = true }

--- a/crates/aranya-client/src/client/device.rs
+++ b/crates/aranya-client/src/client/device.rs
@@ -225,4 +225,17 @@ impl Device<'_> {
             .map_err(IpcError::new)?
             .map_err(aranya_error)
     }
+
+    /// Returns the generation counter for the device, if any.
+    #[cfg(test)]
+    pub async fn generation(&self) -> Result<Option<i64>> {
+        let gen = self
+            .client
+            .daemon
+            .query_device_generation(create_ctx(), self.team_id, self.id)
+            .await
+            .map_err(IpcError::new)?
+            .map_err(aranya_error)?;
+        Ok(gen)
+    }
 }

--- a/crates/aranya-client/src/tests/client.rs
+++ b/crates/aranya-client/src/tests/client.rs
@@ -3013,3 +3013,428 @@ async fn test_outranks_but_missing_permission() -> Result<()> {
 
     Ok(())
 }
+
+/// Assigning the same label to a device twice should fail because the
+/// label assignment already exists with the same generation.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_duplicate_label_assignment_rejected() -> Result<()> {
+    let mut devices = DevicesCtx::new("test_duplicate_label_assignment_rejected").await?;
+    let team_id = devices.create_and_add_team().await?;
+    let roles = devices
+        .setup_default_roles(team_id)
+        .await
+        .context("unable to setup default roles")?;
+    devices.add_all_device_roles(team_id, &roles).await?;
+
+    let owner_team = devices.owner.client.team(team_id);
+    let member_role_rank = owner_team.query_rank(roles.member().id).await?;
+    let label_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    let label = owner_team.create_label(text!("label"), label_rank).await?;
+
+    // First assignment should succeed.
+    owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await
+        .expect("first label assignment should succeed");
+
+    // Second assignment of the same label should fail.
+    let err = owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await
+        .expect_err("duplicate label assignment should fail");
+    assert!(matches!(err, crate::Error::Aranya(_)), "{err:?}");
+
+    Ok(())
+}
+
+/// When a device is removed and re-added, old label assignments become
+/// stale (generation mismatch). Reassigning the label should succeed.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_device_generation_counter_label_reassignment() -> Result<()> {
+    let mut devices = DevicesCtx::new("test_device_generation_counter_label_reassignment").await?;
+    let team_id = devices.create_and_add_team().await?;
+    let roles = devices
+        .setup_default_roles(team_id)
+        .await
+        .context("unable to setup default roles")?;
+    devices.add_all_device_roles(team_id, &roles).await?;
+
+    let owner_team = devices.owner.client.team(team_id);
+    let member_role_rank = owner_team.query_rank(roles.member().id).await?;
+    let label_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    let label = owner_team.create_label(text!("label"), label_rank).await?;
+
+    // Generation counter should start at 0.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(0), "initial generation should be 0");
+
+    // Assign label to membera.
+    owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await?;
+
+    // Verify label is visible.
+    let labels = owner_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(labels.iter().count(), 1, "label should be assigned");
+
+    // Remove membera from team.
+    owner_team
+        .device(devices.membera.id)
+        .remove_from_team()
+        .await?;
+
+    // Generation counter increments on removal.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(1), "generation should be 1 after removal");
+
+    // Re-add membera with the member role.
+    let device_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    owner_team
+        .add_device(
+            devices.membera.pk.clone(),
+            Some(roles.member().id),
+            device_rank,
+        )
+        .await?;
+
+    // Generation counter should not change on re-add.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(1), "generation should still be 1 after re-add");
+
+    // Old label assignment should be stale (not visible).
+    let labels = owner_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(
+        labels.iter().count(),
+        0,
+        "stale label should not be visible"
+    );
+
+    // Reassigning the same label should succeed (stale gen < current gen).
+    owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await?;
+
+    // Generation counter should still be 1 (reassignment doesn't change it).
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(
+        gen,
+        Some(1),
+        "generation should still be 1 after reassignment"
+    );
+
+    // Label should now be visible.
+    let labels = owner_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(
+        labels.iter().count(),
+        1,
+        "reassigned label should be visible"
+    );
+
+    Ok(())
+}
+
+/// Adding the same device to a team twice should fail because the
+/// Device fact already exists.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_add_device_to_team_twice_rejected() -> Result<()> {
+    let mut devices = DevicesCtx::new("test_add_device_to_team_twice_rejected").await?;
+    let team_id = devices.create_and_add_team().await?;
+    let roles = devices
+        .setup_default_roles(team_id)
+        .await
+        .context("unable to setup default roles")?;
+    devices.add_all_device_roles(team_id, &roles).await?;
+
+    let owner_team = devices.owner.client.team(team_id);
+    let member_role_rank = owner_team.query_rank(roles.member().id).await?;
+    let device_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+
+    // Try to add membera again (already on team).
+    let err = owner_team
+        .add_device(
+            devices.membera.pk.clone(),
+            Some(roles.member().id),
+            device_rank,
+        )
+        .await
+        .expect_err("adding same device twice should fail");
+    assert!(matches!(err, crate::Error::Aranya(_)), "{err:?}");
+
+    Ok(())
+}
+
+/// Revoking a label from a device that was removed from the team should
+/// fail. Additionally, if a label was assigned before the device was
+/// removed and the device is later re-added, attempting to revoke that
+/// old assignment should also fail because the generation counter no
+/// longer matches.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_revoke_stale_label_assignment_rejected() -> Result<()> {
+    let mut devices = DevicesCtx::new("test_revoke_stale_label_assignment_rejected").await?;
+    let team_id = devices.create_and_add_team().await?;
+    let roles = devices
+        .setup_default_roles(team_id)
+        .await
+        .context("unable to setup default roles")?;
+    devices.add_all_device_roles(team_id, &roles).await?;
+
+    let owner_team = devices.owner.client.team(team_id);
+    let member_role_rank = owner_team.query_rank(roles.member().id).await?;
+    let label_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    let label = owner_team.create_label(text!("label"), label_rank).await?;
+
+    // Generation should start at 0.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(0), "initial generation should be 0");
+
+    // Assign label to membera.
+    owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await
+        .expect("label assignment should succeed");
+
+    // Remove membera from team.
+    owner_team
+        .device(devices.membera.id)
+        .remove_from_team()
+        .await
+        .expect("remove_from_team should succeed");
+
+    // Generation counter increments on removal.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(1), "generation should be 1 after removal");
+
+    // Revoking a label from a removed device should fail.
+    let err = owner_team
+        .device(devices.membera.id)
+        .revoke_label(label)
+        .await
+        .expect_err("revoking label from removed device should fail");
+    assert!(matches!(err, crate::Error::Aranya(_)), "{err:?}");
+
+    // Re-add membera with the member role.
+    let device_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    owner_team
+        .add_device(
+            devices.membera.pk.clone(),
+            Some(roles.member().id),
+            device_rank,
+        )
+        .await
+        .expect("re-adding device should succeed");
+
+    // Generation counter should not change on re-add.
+    let gen = owner_team
+        .device(devices.membera.id)
+        .generation()
+        .await
+        .expect("generation should succeed");
+    assert_eq!(gen, Some(1), "generation should still be 1 after re-add");
+
+    // Try to revoke the stale label assignment (generation mismatch).
+    let err = owner_team
+        .device(devices.membera.id)
+        .revoke_label(label)
+        .await
+        .expect_err("revoking stale label assignment should fail");
+    assert!(matches!(err, crate::Error::Aranya(_)), "{err:?}");
+
+    Ok(())
+}
+
+/// When one device assigns a label and another concurrently removes the
+/// target device (without syncing), the label assignment should be
+/// invalidated after syncing because its embedded generation counter
+/// won't match the device's current generation after reordering.
+///
+/// RemoveDevice has priority 400 and AssignLabelToDevice has priority
+/// 100, so the braid deterministically orders the remove before the
+/// assign when they are concurrent. This means:
+///   1. RemoveDevice runs first, bumping device_gen from 0 to 1.
+///   2. AssignLabelToDevice runs second with embedded device_gen=0,
+///      but the device's current gen is now 1 — the check fails.
+///
+/// Timeline:
+///   owner: assign label to membera (captures device_gen=0)
+///   admin: remove membera from team (bumps device_gen to 1)
+///   (no sync between owner and admin during these operations)
+///   sync all -> braid reorders remove before assign (priority 400 > 100)
+///   -> assign fails because device_gen=0 != current_gen=1
+///   owner: re-add membera (device_gen stays 1)
+///   -> label should not be assigned
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_concurrent_label_assign_and_device_removal() -> Result<()> {
+    let mut devices = DevicesCtx::new("test_concurrent_label_assign_and_device_removal").await?;
+    let team_id = devices.create_and_add_team().await?;
+    let roles = devices
+        .setup_default_roles(team_id)
+        .await
+        .context("unable to setup default roles")?;
+    devices.add_all_device_roles(team_id, &roles).await?;
+
+    let owner_team = devices.owner.client.team(team_id);
+
+    // Create a label that can be assigned to members.
+    let member_role_rank = owner_team.query_rank(roles.member().id).await?;
+    let label_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    let label = owner_team.create_label(text!("label"), label_rank).await?;
+
+    // Sync so admin sees all devices and the label.
+    let owner_addr = devices.owner.aranya_local_addr().await?;
+    let admin_team = devices.admin.client.team(team_id);
+    admin_team.sync_now(owner_addr, None).await?;
+
+    // Verify initial generation is 0 on both devices.
+    let gen = owner_team.device(devices.membera.id).generation().await?;
+    assert_eq!(gen, Some(0), "initial generation should be 0 on owner");
+    let gen = admin_team.device(devices.membera.id).generation().await?;
+    assert_eq!(gen, Some(0), "initial generation should be 0 on admin");
+
+    // --- Concurrent operations without syncing ---
+    // Owner assigns the label to membera (captures device_gen=0).
+    owner_team
+        .device(devices.membera.id)
+        .assign_label(label, ChanOp::SendRecv)
+        .await
+        .expect("label assignment should succeed locally");
+
+    // On the owner's device the label assignment is valid and gen is still 0.
+    let labels = owner_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(
+        labels.iter().count(),
+        1,
+        "label should be assigned on owner before sync"
+    );
+    let gen = owner_team.device(devices.membera.id).generation().await?;
+    assert_eq!(
+        gen,
+        Some(0),
+        "generation should still be 0 on owner before sync"
+    );
+
+    // Admin removes membera from the team (bumps device_gen to 1).
+    // Admin has not synced with owner, so it doesn't know about the
+    // label assignment.
+    admin_team
+        .device(devices.membera.id)
+        .remove_from_team()
+        .await
+        .expect("remove should succeed locally");
+
+    // On admin, the generation was bumped to 1 by the removal.
+    let gen = admin_team.device(devices.membera.id).generation().await?;
+    assert_eq!(
+        gen,
+        Some(1),
+        "generation should be 1 on admin after removal"
+    );
+
+    // Owner still sees gen=0 because it hasn't synced the removal yet.
+    let gen = owner_team.device(devices.membera.id).generation().await?;
+    assert_eq!(
+        gen,
+        Some(0),
+        "generation should still be 0 on owner before sync"
+    );
+
+    // --- Sync to trigger braid reordering ---
+    // RemoveDevice (priority 400) is ordered before AssignLabelToDevice
+    // (priority 100) by the braid. After syncing:
+    //   1. Both devices evaluate RemoveDevice first -> gen bumps to 1.
+    //   2. Both devices evaluate AssignLabelToDevice second -> check
+    //      fails because embedded device_gen=0 != current gen=1.
+    admin_team.sync_now(owner_addr, None).await?;
+    // Sync back to owner so it sees the removal.
+    owner_team
+        .sync_now(devices.admin.aranya_local_addr().await?, None)
+        .await?;
+
+    // After sync, both devices should agree: gen is 1 because the
+    // remove was processed. The label assignment was rejected.
+    let gen = owner_team.device(devices.membera.id).generation().await?;
+    assert_eq!(gen, Some(1), "generation should be 1 on owner after sync");
+
+    // Re-add membera so we can query label state for this device.
+    let device_rank = Rank::new(member_role_rank.value().saturating_sub(1));
+    owner_team
+        .add_device(
+            devices.membera.pk.clone(),
+            Some(roles.member().id),
+            device_rank,
+        )
+        .await
+        .context("re-adding device should succeed")?;
+
+    // Generation stays at 1 after re-add (only removal increments it).
+    let gen = owner_team.device(devices.membera.id).generation().await?;
+    assert_eq!(gen, Some(1), "generation should still be 1 after re-add");
+
+    // The label that was previously assigned (and valid before sync)
+    // should NOT be assigned now. The concurrent removal changed the
+    // generation to 1, so the assignment authored with device_gen=0
+    // was rejected during braid evaluation.
+    let labels = owner_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(
+        labels.iter().count(),
+        0,
+        "label should not be assigned after concurrent removal invalidated the assignment"
+    );
+
+    // Verify on the admin's device as well.
+    admin_team.sync_now(owner_addr, None).await?;
+    let labels = admin_team
+        .device(devices.membera.id)
+        .label_assignments()
+        .await?;
+    assert_eq!(
+        labels.iter().count(),
+        0,
+        "label should not be assigned on admin after sync either"
+    );
+
+    Ok(())
+}

--- a/crates/aranya-daemon-api/Cargo.toml
+++ b/crates/aranya-daemon-api/Cargo.toml
@@ -24,6 +24,9 @@ afc = ["dep:aranya-fast-channels"]
 # Experimental features
 experimental = []
 
+# Test utilities (not part of the public API)
+test-utils = []
+
 
 [dependencies]
 aranya-util = { workspace = true }

--- a/crates/aranya-daemon-api/src/service.rs
+++ b/crates/aranya-daemon-api/src/service.rs
@@ -495,6 +495,11 @@ pub trait DaemonApi {
     /// Queries the rank of an object.
     async fn query_rank(team: TeamId, object_id: ObjectId) -> Result<Rank>;
 
+    /// Queries the generation counter for a device.
+    #[cfg(feature = "test-utils")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
+    async fn query_device_generation(team: TeamId, device_id: DeviceId) -> Result<Option<i64>>;
+
     //
     // Role assignment
     //

--- a/crates/aranya-daemon/Cargo.toml
+++ b/crates/aranya-daemon/Cargo.toml
@@ -27,6 +27,9 @@ afc = ["aranya-daemon-api/afc", "dep:aranya-fast-channels"]
 # Experimental features
 experimental = ["aranya-daemon-api/experimental"]
 
+# Test utilities (not part of the public API)
+test-utils = ["aranya-daemon-api/test-utils"]
+
 
 [dependencies]
 aranya-daemon-api = { workspace = true, default-features = false }

--- a/crates/aranya-daemon/src/actions.rs
+++ b/crates/aranya-daemon/src/actions.rs
@@ -254,6 +254,18 @@ where
         .in_current_span()
     }
 
+    /// Invokes `query_device_generation`.
+    #[cfg(feature = "test-utils")]
+    #[instrument(skip(self))]
+    fn query_device_generation(
+        &self,
+        device_id: DeviceId,
+    ) -> impl Future<Output = Result<Vec<Effect>>> + Send {
+        self.call_session_action(policy::query_device_generation(device_id.as_base()))
+            .map_ok(|SessionData { effects, .. }| effects)
+            .in_current_span()
+    }
+
     /// Invokes `query_rank`.
     #[allow(clippy::type_complexity)]
     #[instrument(skip(self))]

--- a/crates/aranya-daemon/src/api.rs
+++ b/crates/aranya-daemon/src/api.rs
@@ -265,6 +265,7 @@ impl EffectHandler {
                 QueryRoleHasPermResult(_) => {}
                 QueryRolePermsResult(_) => {}
                 QueryRankResult(_) => {}
+                QueryDeviceGenerationResult(_) => {}
                 RankChanged(_) => {}
                 RoleCreated(_) => {}
                 RoleDeleted(_) => {}
@@ -1361,6 +1362,32 @@ impl DaemonApi for Api {
             Ok(api::Rank::new(e.rank))
         } else {
             Err(anyhow!("rank not found for object").into())
+        }
+    }
+
+    #[cfg(feature = "test-utils")]
+    #[instrument(skip(self), err)]
+    async fn query_device_generation(
+        self,
+        _: context::Context,
+        team: api::TeamId,
+        device_id: api::DeviceId,
+    ) -> api::Result<Option<i64>> {
+        let graph = self.check_team_valid(team).await?;
+
+        let effects = self
+            .client
+            .actions(graph)
+            .query_device_generation(DeviceId::transmute(device_id))
+            .await
+            .context("unable to query device generation")?;
+
+        if let Some(Effect::QueryDeviceGenerationResult(e)) =
+            find_effect!(&effects, Effect::QueryDeviceGenerationResult(_))
+        {
+            Ok(Some(e.generation))
+        } else {
+            Ok(None)
         }
     }
 }

--- a/crates/aranya-daemon/src/policy.md
+++ b/crates/aranya-daemon/src/policy.md
@@ -1088,6 +1088,60 @@ ephemeral command QueryRank {
 }
 ```
 
+### Device Generation Queries
+
+##### `query_device_generation`
+
+Returns the generation counter for a device. This query is intended
+for testing only and should not be exposed via any public APIs.
+
+<!-- TODO: Add conditional compilation to the policy language so
+     test-only actions/commands can be gated at the policy level. -->
+
+```policy
+// Emits `QueryDeviceGenerationResult` with the generation counter
+// for the device. If the device does not have a generation counter,
+// then no effect is emitted.
+ephemeral action query_device_generation(device_id id) {
+    publish QueryDeviceGeneration {
+        device_id: device_id,
+    }
+}
+
+effect QueryDeviceGenerationResult {
+    // The device's unique ID.
+    device_id id,
+    // The device's generation counter.
+    generation int,
+}
+
+ephemeral command QueryDeviceGeneration {
+    fields {
+        device_id id,
+    }
+
+    seal { return seal_command(serialize(this)) }
+    open { return deserialize(open_envelope(envelope)) }
+
+    policy {
+        check team_exists()
+
+        let maybe_gen = query DeviceGeneration[device_id: this.device_id]
+        if maybe_gen is None {
+            finish {}
+        } else {
+            let gen = unwrap maybe_gen
+            finish {
+                emit QueryDeviceGenerationResult {
+                    device_id: this.device_id,
+                    generation: gen.generation,
+                }
+            }
+        }
+    }
+}
+```
+
 ## Roles and Permissions
 <!-- Section contains: Role facts, permissions, assignment/revocation, default roles -->
 
@@ -3126,6 +3180,8 @@ fact LabelAssignedToDevice[label_id id, device_id id]=>{op enum ChanOp, device_g
 // - It is an error if the device has already been granted
 //   permission to use this label for its current generation.
 // - It is an error if the device is not permitted to use AFC.
+// - It is an error if the device's generation has changed since
+//   the action was authored (stale membership epoch).
 //
 // # Required Permissions
 //
@@ -3133,10 +3189,13 @@ fact LabelAssignedToDevice[label_id id, device_id id]=>{op enum ChanOp, device_g
 //
 // Additionally, the target device must have `CanUseAfc` permissions
 action assign_label_to_device(device_id id, label_id id, op enum ChanOp) {
+    // Bind the command to this membership epoch.
+    let gen = get_device_gen(device_id)
     publish AssignLabelToDevice {
         device_id: device_id,
         label_id: label_id,
         op: op,
+        device_gen: gen,
     }
 }
 
@@ -3164,6 +3223,8 @@ command AssignLabelToDevice {
         // The channel operations the device is allowed to use
         // the label for.
         op enum ChanOp,
+        // Device generation at authoring time; rejects stale epochs.
+        device_gen int,
     }
 
     seal { return seal_command(serialize(this)) }
@@ -3185,12 +3246,14 @@ command AssignLabelToDevice {
         // The target device must be able to use AFC.
         check device_has_perm(this.device_id, Perm::CanUseAfc)
 
+        // Reject if the device's membership epoch changed (e.g. reordered remove/re-add).
+        let current_gen = get_device_gen(this.device_id)
+        check this.device_gen == current_gen
+
         let existing_assignment = query LabelAssignedToDevice[
             label_id: this.label_id,
             device_id: this.device_id,
         ]
-
-        let current_gen = get_device_gen(this.device_id)
 
         if existing_assignment is Some {
             // Only allow reuse when the stored assignment is
@@ -3205,6 +3268,7 @@ command AssignLabelToDevice {
             // - `author` outranks `this.device_id`
             // - `this.device_id` refers to a device that exists
             // - `this.label_id` refers to a label that exists
+            // - the command's generation matches the device's current generation
             // - the existing assignment is stale because the device has
             //   been re-provisioned
             finish {
@@ -3233,13 +3297,14 @@ command AssignLabelToDevice {
             // - `author` outranks `this.device_id`
             // - `this.device_id` refers to a device that exists
             // - `this.label_id` refers to a label that exists
+            // - the command's generation matches the device's current generation
             finish {
                 create LabelAssignedToDevice[
                     label_id: this.label_id,
                     device_id: this.device_id,
                 ]=>{
                     op: this.op,
-                    device_gen: current_gen,
+                    device_gen: this.device_gen,
                 }
 
                 emit AssignedLabelToDevice {
@@ -3317,10 +3382,18 @@ command RevokeLabelFromDevice {
         // We need to get label info before deleting
         let label = check_unwrap query Label[label_id: this.label_id]
 
-        check exists LabelAssignedToDevice[
+        let assignment = check_unwrap query LabelAssignedToDevice[
             label_id: this.label_id,
             device_id: this.device_id,
         ]
+        // Reject revocations of stale label assignments. When a
+        // device is removed and re-added its generation counter is
+        // incremented, which implicitly invalidates all prior label
+        // assignments. Revoking one of those stale assignments
+        // would delete the fact row and prevent a future (valid)
+        // assign from reusing it via the `device_gen < current_gen`
+        // update path.
+        check label_assignment_matches_gen(this.device_id, assignment.device_gen)
 
         // At this point we believe the following to be true:
         //
@@ -3329,6 +3402,7 @@ command RevokeLabelFromDevice {
         // - `author` outranks `this.device_id`
         // - `author` outranks `this.label_id`
         // - `this.label_id` refers to a label that exists
+        // - the label assignment matches the device's current generation
         finish {
             delete LabelAssignedToDevice[
                 label_id: this.label_id,

--- a/crates/aranya-daemon/src/policy.rs
+++ b/crates/aranya-daemon/src/policy.rs
@@ -78,6 +78,7 @@ pub enum Effect {
     PermAddedToRole(PermAddedToRole),
     PermRemovedFromRole(PermRemovedFromRole),
     QueryAfcChannelIsValidResult(QueryAfcChannelIsValidResult),
+    QueryDeviceGenerationResult(QueryDeviceGenerationResult),
     QueryDeviceKeyBundleResult(QueryDeviceKeyBundleResult),
     QueryDeviceRoleResult(QueryDeviceRoleResult),
     QueryDevicesOnTeamResult(QueryDevicesOnTeamResult),
@@ -187,6 +188,12 @@ pub struct QueryAfcChannelIsValidResult {
     pub receiver_id: BaseId,
     pub label_id: BaseId,
     pub is_valid: bool,
+}
+/// QueryDeviceGenerationResult policy effect.
+#[effect]
+pub struct QueryDeviceGenerationResult {
+    pub device_id: BaseId,
+    pub generation: i64,
 }
 /// QueryDeviceKeyBundleResult policy effect.
 #[effect]
@@ -337,6 +344,7 @@ pub enum EphemeralAction {
     query_device_role(query_device_role),
     query_device_public_key_bundle(query_device_public_key_bundle),
     query_rank(query_rank),
+    query_device_generation(query_device_generation),
     query_team_roles(query_team_roles),
     query_role_has_perm(query_role_has_perm),
     query_role_perms(query_role_perms),
@@ -376,6 +384,11 @@ pub struct change_rank {
 #[action(interface = Ephemeral)]
 pub struct query_rank {
     pub object_id: BaseId,
+}
+/// query_device_generation policy action.
+#[action(interface = Ephemeral)]
+pub struct query_device_generation {
+    pub device_id: BaseId,
 }
 /// add_perm_to_role policy action.
 #[action(interface = Persistent)]


### PR DESCRIPTION
## Summary

Closes #549.

- **Fix `RevokeLabelFromDevice` generation check** -- The command previously used `check exists` without validating the device generation counter, allowing revocation of stale label assignments after a device was removed and re-added. Now uses `check_unwrap query` + `label_assignment_matches_gen` to reject stale revocations.
- **Embed device generation in `AssignLabelToDevice` command fields** -- The action now captures the device's generation counter at authoring time and the policy block verifies it matches the current generation. This prevents braid reordering (RemoveDevice priority 400 > AssignLabelToDevice priority 100) from silently assigning a label to a different membership epoch when a concurrent device removal changes the generation.
- **Add `query_device_generation` test-only API** -- New ephemeral action/command/effect wired through all layers (policy, daemon, client) behind a `test-utils` feature flag. Enables tests to assert generation counter values at each step.
- **Add five integration tests** covering generation counter behavior:
  - `test_duplicate_label_assignment_rejected` -- assigning the same label twice fails
  - `test_device_generation_counter_label_reassignment` -- stale labels become invisible after remove/re-add; reassignment succeeds
  - `test_add_device_to_team_twice_rejected` -- adding an existing device fails
  - `test_revoke_stale_label_assignment_rejected` -- revoking a stale label fails (validates the bug fix)
  - `test_concurrent_label_assign_and_device_removal` -- concurrent label assignment and device removal on different devices; verifies braid reordering invalidates the assignment via generation counter mismatch

## Test plan

- [x] All new tests pass: `TMPDIR=/dev/shm cargo test -p aranya-client`
- [x] Full test suite passes (53/53): `TMPDIR=/dev/shm cargo test -p aranya-client`
- [x] Clippy clean on changed crates: `cargo clippy -p aranya-client -p aranya-daemon -p aranya-daemon-api --all-features`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)