### PR TITLE
fix: delegate member/label operations from owner to admin and operator in example

### DIFF
--- a/examples/rust/aranya-example/src/main.rs
+++ b/examples/rust/aranya-example/src/main.rs
@@ -428,9 +428,10 @@ async fn main() -> Result<()> {
         .assign_role(member_role.id)
         .await?;
 
-    // Sync membera and memberb so they see their team membership and roles.
-    membera_team.sync_now(owner_addr, None).await?;
-    memberb_team.sync_now(owner_addr, None).await?;
+    // Sync membera and memberb with the operator so they see their
+    // team membership (added by admin) and role assignments (by operator).
+    membera_team.sync_now(operator_addr, None).await?;
+    memberb_team.sync_now(operator_addr, None).await?;
 
     // Demo custom roles.
     info!("demo custom roles functionality");
@@ -545,9 +546,9 @@ async fn main() -> Result<()> {
         .assign_label(label3, op)
         .await?;
 
-    // Sync membera and memberb so they see the label assignments.
-    membera_team.sync_now(owner_addr, None).await?;
-    memberb_team.sync_now(owner_addr, None).await?;
+    // Sync membera and memberb with the operator so they see the label assignments.
+    membera_team.sync_now(operator_addr, None).await?;
+    memberb_team.sync_now(operator_addr, None).await?;
 
     // Demo AFC.
     info!("demo afc functionality");


### PR DESCRIPTION
Have the admin add members and create labels, and the operator assign labels, instead of having the owner do everything. This matches the delegation pattern already used in aranya-metrics and the multi-node example.