### PR TITLE
fix: allow private_bounds lint on change_rank and query_rank

### DIFF
--- a/crates/aranya-client/src/client/team.rs
+++ b/crates/aranya-client/src/client/team.rs
@@ -349,6 +349,7 @@ impl Team<'_> {
     /// the role. To effectively change a role's rank, create a new role with
     /// matching permissions at the desired rank, assign the new role to the
     /// devices that had the old role, then delete the old role.
+    #[allow(private_bounds)]
     #[instrument(skip(self))]
     pub async fn change_rank(
         &self,
@@ -371,6 +372,7 @@ impl Team<'_> {
     }
 
     /// Queries the rank of an object.
+    #[allow(private_bounds)]
     #[instrument(skip(self))]
     pub async fn query_rank(&self, object_id: impl ToObjectId) -> Result<Rank> {
         self.client


### PR DESCRIPTION
## Summary

- Add `#[allow(private_bounds)]` to `change_rank` and `query_rank` in `team.rs`
- `ToObjectId` is intentionally `pub(crate)` but used in public method signatures, triggering `-D warnings` in CI
- This suppresses the lint until the trait's public API design is resolved

## Prerequisite for

- #766 (release: 6.0.0)

## Test plan

- [ ] CI passes (`cargo clippy -p aranya-client -- -D warnings` verified locally)
- [ ] `cargo test -p aranya-client` passes (63 unit tests + 7 integration tests verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)