### PR TITLE
chore: ignore rand advisory and update rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -76,11 +76,9 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # The `paste` crate is unmaintained. There isn't anything we
-    # can do here.
-    "RUSTSEC-2024-0436",
-    # The `rustls-pemfile` crate is unmaintained. We're not using certs anyways.
-    "RUSTSEC-2025-0134",
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but finished" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained. We're not using certs anyways" },
+    { id = "RUSTSEC-2026-0097", reason = "we don't use the features required to hit the bug" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -410,6 +410,11 @@ criteria = "safe-to-deploy"
 delta = "0.103.3 -> 0.103.10"
 notes = "Certificate/crypto fixes to solve reported CVE."
 
+[[audits.rustls-webpki]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.103.10 -> 0.103.12"
+
 [[audits.rustversion]]
 who = "gknopf <gknopf@spideroak.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2026-0097
https://rustsec.org/advisories/RUSTSEC-2026-0098
https://rustsec.org/advisories/RUSTSEC-2026-0099