### PR TITLE
chore: security updates

### DIFF
--- a/.github/workflows/correctness.yml
+++ b/.github/workflows/correctness.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           sudo apt-get install -y lsb-release wget software-properties-common gnupg
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 200
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 200
           clang-format --version
 
       - name: Check formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "aranya-afc-util"
@@ -195,7 +195,7 @@ dependencies = [
  "buggy",
  "postcard",
  "serde",
- "spin 0.10.0",
+ "spin",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -491,7 +491,7 @@ dependencies = [
  "const_format",
  "derive-where",
  "errno",
- "heapless 0.8.0",
+ "heapless",
  "libc",
  "serde",
  "thiserror 2.0.12",
@@ -737,7 +737,7 @@ dependencies = [
  "aranya-policy-derive",
  "aranya-policy-module",
  "buggy",
- "heapless 0.8.0",
+ "heapless",
  "postcard-core",
  "serde",
  "thiserror 2.0.12",
@@ -753,11 +753,11 @@ dependencies = [
  "aranya-libc",
  "aranya-policy-vm",
  "buggy",
- "heapless 0.8.0",
+ "heapless",
  "postcard",
  "serde",
  "spideroak-base58",
- "spin 0.10.0",
+ "spin",
  "thiserror 2.0.12",
  "tracing",
  "vec1",
@@ -832,15 +832,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -1269,12 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1922,15 +1907,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -1955,25 +1931,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32 0.3.1",
+ "hash32",
  "serde",
  "stable_deref_trait",
 ]
@@ -2890,7 +2852,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless 0.7.17",
  "postcard-derive",
  "serde",
 ]
@@ -3110,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.1",
@@ -3352,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "hashbrown 0.17.1",
@@ -3369,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3576,15 +3537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,12 +3561,6 @@ dependencies = [
  "salsa20",
  "sha2",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "sec1"
@@ -3752,23 +3698,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3917,7 +3863,7 @@ dependencies = [
  "sha2",
  "sha3-utils",
  "spideroak-crypto-derive",
- "spin 0.10.0",
+ "spin",
  "subtle",
  "thiserror 2.0.12",
  "typenum",
@@ -3938,18 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ http = { version = "1" }
 libc = { version = "0.2" }
 metrics = { version = "0.24" }
 metrics-util = { version = "0.20" }
-postcard = { version = "1", default-features = false, features = ["use-std", "heapless", "experimental-derive"] }
+postcard = { version = "1", default-features = false, features = ["use-std", "experimental-derive"] }
 pretty_assertions = { version = "1.4" }
 quinn = { version = "0.11", default-features = false, features = ["rustls", "runtime-tokio"] }
 rand = { version = "0.8" }

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,7 @@ yanked = "warn"
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but finished" },
     { id = "RUSTSEC-2026-0097", reason = "we don't use the features required to hit the bug" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is an unmaintained build-time sub-dependency" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -242,17 +243,14 @@ skip = [
     "getrandom@0.2.15",
     "getrandom@0.3.1",
     "hashbrown@0.15.2",
-    "heapless@0.7.17",
-    "hash32@0.2.1",
     "linux-raw-sys@0.4.15",
     "petgraph@0.7.1",
     "rand@0.8.5",
     "rand_chacha@0.3.1",
     "rand_core@0.6.4",
-    "rustix@0.38.44",
     "rustc-hash@1.1.0",
+    "rustix@0.38.44",
     "socket2@0.5.8",
-    "spin@0.9.8",
     "thiserror-impl@1.0.69",
     "thiserror@1.0.69",
     "toml@0.5.11",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -16,6 +16,11 @@ who = "gknopf <gknopf@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.94 -> 1.0.97"
 
+[[audits.anyhow]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.103 -> 1.0.104"
+
 [[audits.asn1-rs]]
 who = "gknopf <gknopf@spideroak.com>"
 criteria = "safe-to-deploy"
@@ -306,6 +311,11 @@ who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.11.13 -> 0.11.14"
 notes = "Some trivial refactoring plus the RUSTSEC-2026-0037 unwrap fix."
+
+[[audits.quinn-proto]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.11.14 -> 0.11.15"
 
 [[audits.quote]]
 who = "gknopf <gknopf@spideroak.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -105,10 +105,6 @@ criteria = "safe-to-run"
 version = "0.1.83"
 criteria = "safe-to-deploy"
 
-[[exemptions.atomic-polyfill]]
-version = "1.0.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.aws-lc-rs]]
 version = "1.13.0"
 criteria = "safe-to-deploy"
@@ -208,10 +204,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
 version = "0.2.16"
-criteria = "safe-to-deploy"
-
-[[exemptions.critical-section]]
-version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-channel]]
@@ -461,7 +453,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.lock_api]]
 version = "0.4.12"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.lru-slab]]
 version = "0.1.2"
@@ -779,20 +771,12 @@ criteria = "safe-to-deploy"
 version = "0.10.2"
 criteria = "safe-to-run"
 
-[[exemptions.scc]]
-version = "2.2.5"
-criteria = "safe-to-run"
-
 [[exemptions.schannel]]
 version = "0.1.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.scrypt]]
 version = "0.11.0"
-criteria = "safe-to-run"
-
-[[exemptions.sdd]]
-version = "3.0.4"
 criteria = "safe-to-run"
 
 [[exemptions.sec1]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -516,10 +516,30 @@ who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.13 -> 0.8.16"
 
+[[audits.aranya-core.audits.rkyv]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.16 -> 0.8.17"
+
 [[audits.aranya-core.audits.rkyv_derive]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.13 -> 0.8.16"
+
+[[audits.aranya-core.audits.rkyv_derive]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.16 -> 0.8.17"
+
+[[audits.aranya-core.audits.serial_test]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+delta = "3.2.0 -> 3.5.0"
+
+[[audits.aranya-core.audits.serial_test_derive]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+delta = "3.2.0 -> 3.5.0"
 
 [[audits.aranya-core.audits.sha3-utils]]
 who = "Eric Lagergren <elagergren@spideroak.com>"
@@ -530,6 +550,11 @@ delta = "0.3.0 -> 0.5.0"
 who = "Eric Lagergren <elagergren@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.8 -> 0.10.0"
+
+[[audits.aranya-core.audits.spin]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.10.1"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -668,6 +693,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.15 -> 0.9.18"
 notes = "Nontrivial update but mostly around dependencies and how `unsafe` code is managed. Everything looks the same shape as before."
+
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
 
 [[audits.bytecode-alliance.audits.crypto-common]]
 who = "Benjamin Bouvier <public@benj.me>"
@@ -2289,6 +2320,12 @@ criteria = "safe-to-deploy"
 delta = "1.0.71 -> 1.0.95"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.anyhow]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.95 -> 1.0.103"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.basic-toml]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -2431,6 +2468,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.13 -> 0.9.14"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-epoch]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.14 -> 0.9.15"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crossbeam-utils]]
@@ -3117,12 +3160,6 @@ criteria = "safe-to-deploy"
 delta = "0.11.2 -> 0.11.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.zcash.audits.anyhow]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.95 -> 1.0.97"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.async-trait]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3195,13 +3232,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.2.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.crossbeam-epoch]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.9.14 -> 0.9.15"
-notes = "Bumps memoffset to 0.9, and unmarks some ARMv7r and Sony Vita targets as not having 64-bit atomics."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.crossbeam-utils]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
Addresses 8 advisories and 2 yanked versions

- https://rustsec.org/advisories/RUSTSEC-2026-0173
- https://rustsec.org/advisories/RUSTSEC-2026-0185
- https://rustsec.org/advisories/RUSTSEC-2026-0190
- https://rustsec.org/advisories/RUSTSEC-2026-0204
- https://rustsec.org/advisories/RUSTSEC-2026-0205
- https://rustsec.org/advisories/RUSTSEC-2026-0233
- https://rustsec.org/advisories/RUSTSEC-2026-0234
- https://rustsec.org/advisories/RUSTSEC-2026-0235
- yanked spin@0.9.8
- yanked spin@0.10.0

Also updates to clang-format-22 to avoid new issue around not properly detecting files as C.